### PR TITLE
docs: add project reference docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Project Docs - GIS Du lịch miền Trung
+
+Thư mục này là tài liệu làm việc cho project IE402, được tổng hợp từ báo cáo `IE402.Q21_DoAn_Nhom4.docx` và source code hiện tại trong `be/` + `fe/`.
+
+Mục tiêu chính: giúp thành viên mới, reviewer và Codex đọc nhanh bối cảnh trước khi code tiếp, thay vì phải mở lại toàn bộ báo cáo Word.
+
+## Đọc Theo Thứ Tự
+
+1. [Product Overview](product/overview.md): phạm vi đề tài, actor, MVP và phần nâng cao.
+2. [Feature Coverage](product/feature-coverage.md): đối chiếu chức năng trong báo cáo với route/source/issue hiện tại.
+3. [GIS Overview](gis/overview.md): lớp dữ liệu GIS, hệ tọa độ, bản đồ, định tuyến.
+4. [Data Model](data/model.md): entity, bảng, quan hệ và trường không gian PostGIS.
+5. [Backend Guide](backend/overview.md): kiến trúc backend Express/PostgreSQL cần hướng tới.
+6. [Frontend Guide](frontend/overview.md): route, layout, component và module FE.
+7. [Team Workflow](team/workflow.md): cách chia việc, branch, PR, review.
+8. [Codex Context](codex-context.md): ghi chú ngắn cho những lần Codex sau.
+
+## Trả Lời Nhanh Về Coverage
+
+Các route/core use-case chính trong báo cáo đã được cover ở mức khung route + issue lớn:
+
+- User: đăng ký, đăng nhập, bản đồ, lớp dữ liệu, tìm kiếm/lọc, chi tiết địa điểm, chỉ đường, thời tiết/giao thông, tạo/lưu tour, đánh giá.
+- Admin: đăng nhập, dashboard, quản lý điểm du lịch, dịch vụ, loại hình, thông báo, thời tiết, giao thông, đánh giá, kiểm duyệt.
+- Data/GIS: Province, DestinationCategory, TouristDestination, ServiceFacility, User, TourPlan, Review, Notification, WeatherInfo, TrafficInfo.
+
+Tuy nhiên các chức năng sáng tạo/nâng cao trong báo cáo như StoryMaps, Geo-Gamification, Hidden Gems, Deep Offline, Geofencing và Spatial Analytics hiện mới nên xem là roadmap mở rộng. Nếu giảng viên yêu cầu demo đầy đủ, cần tạo issue riêng cho các phần đó.
+
+## Source Hiện Tại
+
+- `be/`: Express.js + PostgreSQL scaffold, hiện mới có route cơ bản và kết nối `pg`.
+- `fe/`: Next.js App Router + TypeScript + Tailwind, đã có route/layout placeholder cho user và admin.
+- `.agent/`, `.agents/`, `.claude/`, `.codex/`: folder công cụ/agent local do team thêm, không phải runtime chính của app.

--- a/docs/backend/overview.md
+++ b/docs/backend/overview.md
@@ -1,0 +1,143 @@
+# Backend Guide
+
+## Stack
+
+Backend hiện tại nằm trong `be/`:
+
+- Node.js.
+- Express.js.
+- PostgreSQL qua `pg`.
+- Docker Compose cho database.
+
+Source hiện có:
+
+- `be/server.js`
+- `be/config/db.js`
+- `be/routes/index.js`
+- `be/routes/users.js`
+- `be/docker-compose.yml`
+- `be/.env.example`
+
+## Mục Tiêu Kiến Trúc
+
+Backend nên tách rõ các lớp:
+
+```text
+be/
+  config/
+  controllers/
+  routes/
+  services/
+  middlewares/
+  db/
+  utils/
+  server.js
+```
+
+Không nên viết toàn bộ logic trong route. Route chỉ nhận request và gọi controller/service.
+
+## API Group Đề Xuất
+
+### System
+
+- `GET /api/health`
+
+### Auth/User
+
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/users/me`
+
+### Destinations
+
+- `GET /api/destinations`
+- `GET /api/destinations/:id`
+- `POST /api/admin/destinations`
+- `PUT /api/admin/destinations/:id`
+- `DELETE /api/admin/destinations/:id`
+
+### Categories
+
+- `GET /api/categories`
+- `POST /api/admin/categories`
+- `PUT /api/admin/categories/:id`
+- `DELETE /api/admin/categories/:id`
+
+### Services
+
+- `GET /api/services`
+- `POST /api/admin/services`
+- `PUT /api/admin/services/:id`
+- `DELETE /api/admin/services/:id`
+
+### Tours
+
+- `GET /api/tours`
+- `POST /api/tours`
+- `GET /api/tours/:id`
+
+### Reviews
+
+- `GET /api/reviews`
+- `POST /api/reviews`
+- `GET /api/admin/reviews`
+- `PATCH /api/admin/reviews/:id/moderate`
+
+### Notifications, Weather, Traffic
+
+- `GET /api/notifications`
+- `GET /api/weather`
+- `GET /api/traffic`
+- `POST/PUT/DELETE /api/admin/notifications`
+- `POST/PUT /api/admin/weather`
+- `POST/PUT /api/admin/traffic`
+
+### GIS/GeoJSON
+
+- `GET /api/geo/provinces`
+- `GET /api/geo/roads`
+- `GET /api/geo/tourist-places`
+- `GET /api/geo/services`
+
+## Response Shape Gợi Ý
+
+```json
+{
+  "data": [],
+  "meta": {},
+  "error": null
+}
+```
+
+Với lỗi:
+
+```json
+{
+  "data": null,
+  "meta": {},
+  "error": {
+    "message": "Validation failed",
+    "code": "VALIDATION_ERROR"
+  }
+}
+```
+
+## Environment
+
+`.env.example` nên giữ đủ:
+
+- `PORT=3001`
+- `DB_HOST=localhost`
+- `DB_PORT=5432`
+- `DB_USER=gis_user`
+- `DB_PASSWORD=gis_password`
+- `DB_DATABASE=gis_db`
+- `FRONTEND_URL=http://localhost:3000`
+
+## Testing Tối Thiểu
+
+- Backend start không lỗi.
+- `GET /api/health` trả `200`.
+- Database connect được.
+- API list destinations/services trả JSON.
+- Admin CRUD trả status đúng.

--- a/docs/codex-context.md
+++ b/docs/codex-context.md
@@ -1,0 +1,72 @@
+# Codex Context
+
+Đọc file này khi bắt đầu một phiên Codex mới trong repo.
+
+## Repo
+
+Repo GitHub: `vanthinh26102005/ie402-gis-nhom-4`
+
+Thư mục chính:
+
+- `be/`: backend Express/PostgreSQL.
+- `fe/`: frontend Next.js App Router.
+- `docs/`: tài liệu project từ báo cáo và source hiện tại.
+
+## Báo Cáo Gốc
+
+File báo cáo nằm ngoài repo:
+
+```text
+/Users/a23521500/Documents/NAM_3/IE402-GIS/FINAL/IE402.Q21_DoAn_Nhom4.docx
+```
+
+Khi cần kiểm tra lại yêu cầu nghiệp vụ, dùng Documents plugin đọc file này.
+
+## Nắm Nhanh Project
+
+Ứng dụng là WebGIS du lịch 2D cho Quảng Trị - Huế - Đà Nẵng.
+
+Core cần làm:
+
+- Bản đồ 2D đa lớp.
+- Điểm du lịch, dịch vụ hỗ trợ, ranh giới, tuyến đường.
+- Tìm kiếm/lọc/chi tiết POI.
+- Chỉ đường/tạo tour/đánh giá.
+- Thời tiết/giao thông/thông báo.
+- Admin CRUD dữ liệu.
+
+Không mặc định làm:
+
+- GIS 3D.
+- HBIM.
+- Point cloud.
+- Payment/booking thật.
+- IoT/camera/trạm đo thật.
+
+## Lệnh Hay Dùng
+
+Frontend:
+
+```bash
+npm --prefix fe install
+npm --prefix fe run dev
+npm --prefix fe run lint
+npm --prefix fe run build
+```
+
+Backend:
+
+```bash
+npm --prefix be install
+cd be && docker compose up -d
+npm --prefix be run dev
+```
+
+## Lưu Ý Git
+
+Repo đã từng có lỗi folder duplicate `BE/FE` và `be/fe`. Canonical path là lowercase:
+
+- `be/`
+- `fe/`
+
+Không tạo lại folder uppercase.

--- a/docs/data/model.md
+++ b/docs/data/model.md
@@ -1,0 +1,123 @@
+# Data Model
+
+## Entity Chính
+
+| Entity | Spatial | Mục đích |
+|---|---|---|
+| Province | `boundary_geom` Polygon | Tỉnh/thành, ranh giới hành chính. |
+| DestinationCategory | none | Loại hình du lịch. |
+| TouristDestination | `location_geom` Point | Điểm du lịch/POI. |
+| ServiceFacility | `location_geom` Point | Khách sạn, nhà hàng, bãi đỗ, y tế, trạm xăng. |
+| User | none | Người dùng và admin. |
+| TourPlan | none | Tour do người dùng tạo. |
+| TourPlanDetail | none | Danh sách điểm đến trong tour, thứ tự tham quan. |
+| Review | none | Đánh giá điểm du lịch. |
+| Notification | optional relation to destination | Thông báo theo điểm/khu vực. |
+| WeatherInfo | `location_geom` Point | Thời tiết theo điểm/khu vực. |
+| TrafficInfo | `location_geom` Point hoặc segment | Giao thông theo điểm/khu vực/tuyến. |
+
+## Bảng Và Trường Tối Thiểu
+
+### Province
+
+- `province_id`
+- `name`
+- `code`
+- `description`
+- `boundary_geom geometry(Polygon, 4326)`
+
+### DestinationCategory
+
+- `category_id`
+- `name`
+- `description`
+- `created_at`
+- `updated_at`
+
+### TouristDestination
+
+- `destination_id`
+- `name`
+- `description`
+- `address`
+- `open_time`
+- `close_time`
+- `ticket_price`
+- `image_url`
+- `video_url`
+- `rating`
+- `location_geom geometry(Point, 4326)`
+- `province_id`
+- `category_id`
+- `created_at`
+- `updated_at`
+
+### ServiceFacility
+
+- `service_id`
+- `name`
+- `type`
+- `address`
+- `phone`
+- `rating`
+- `description`
+- `location_geom geometry(Point, 4326)`
+- `province_id`
+- `created_at`
+- `updated_at`
+
+### User
+
+- `user_id`
+- `full_name`
+- `email`
+- `password`
+- `role`
+- `avatar`
+- `birthday`
+- `created_at`
+
+### TourPlan / TourPlanDetail
+
+`TourPlan` lưu metadata tour, `TourPlanDetail` lưu từng điểm đến trong tour.
+
+- `tour_id`, `user_id`, `title`, `description`, `total_distance`, `estimated_duration`
+- `detail_id`, `tour_id`, `destination_id`, `visit_order`, `note`
+
+### Review
+
+- `review_id`
+- `user_id`
+- `destination_id`
+- `content`
+- `score`
+- `created_at`
+- `updated_at`
+
+### Notification / WeatherInfo / TrafficInfo
+
+- Notification: `notification_id`, `destination_id`, `title`, `content`, `type`, `status`
+- WeatherInfo: `weather_id`, `destination_id`, `temperature`, `humidity`, `weather_status`, `wind_speed`, `observed_at`
+- TrafficInfo: `traffic_id`, `destination_id`, `congestion_level`, `status`, `description`, `observed_at`
+
+## Quan Hệ Chính
+
+- Province 1-N TouristDestination.
+- Province 1-N ServiceFacility.
+- DestinationCategory 1-N TouristDestination.
+- User 1-N TourPlan.
+- TourPlan 1-N TourPlanDetail.
+- TouristDestination 1-N TourPlanDetail.
+- User 1-N Review.
+- TouristDestination 1-N Review.
+- TouristDestination 1-N Notification/WeatherInfo/TrafficInfo.
+
+## Seed Data Tối Thiểu
+
+Để FE và BE cùng test, seed nên có:
+
+- 3 province: Quảng Trị, Huế, Đà Nẵng.
+- Ít nhất 6 điểm du lịch.
+- Ít nhất 6 dịch vụ hỗ trợ.
+- Ít nhất 3 loại hình du lịch.
+- Một số review, notification, weather, traffic mẫu.

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -1,0 +1,102 @@
+# Frontend Guide
+
+## Stack
+
+Frontend hiện tại nằm trong `fe/`:
+
+- Next.js App Router.
+- TypeScript.
+- Tailwind CSS.
+- shadcn-style button base.
+- lucide-react icons.
+
+## Layout
+
+User và Admin layout tách riêng:
+
+- User: `UserHeader`, `UserFooter`, `UserLayout`.
+- Admin: `AdminSidebar`, `AdminHeader`, `AdminLayout`.
+
+Không dùng user header cho admin.
+
+## Route User
+
+| Route | Mục đích |
+|---|---|
+| `/` | Trang chủ. |
+| `/auth/login` | Đăng nhập người dùng. |
+| `/auth/register` | Đăng ký người dùng. |
+| `/map` | Bản đồ du lịch 2D. |
+| `/map/layers` | Xem/bật/tắt lớp dữ liệu. |
+| `/destinations` | Tìm kiếm và lọc địa điểm. |
+| `/destinations/[id]` | Chi tiết địa điểm. |
+| `/route` | Chỉ đường. |
+| `/weather-traffic` | Thời tiết/giao thông. |
+| `/tours/create` | Tạo tour. |
+| `/reviews` | Đánh giá địa điểm. |
+
+## Route Admin
+
+| Route | Mục đích |
+|---|---|
+| `/admin/login` | Đăng nhập quản trị. |
+| `/admin` | Tổng quan quản trị. |
+| `/admin/destinations` | Quản lý điểm du lịch. |
+| `/admin/destinations/new` | Thêm điểm du lịch. |
+| `/admin/destinations/[id]/edit` | Sửa điểm du lịch. |
+| `/admin/services` | Quản lý dịch vụ hỗ trợ. |
+| `/admin/categories` | Quản lý loại hình du lịch. |
+| `/admin/notifications` | Quản lý thông báo. |
+| `/admin/weather` | Cập nhật thời tiết. |
+| `/admin/traffic` | Cập nhật giao thông. |
+| `/admin/reviews` | Quản lý đánh giá. |
+| `/admin/reviews/[id]/moderate` | Kiểm duyệt đánh giá. |
+
+## Component Hiện Có
+
+Common:
+
+- `Button`
+- `Input`
+- `Select`
+- `Card`
+- `PagePlaceholder`
+- `DataTablePlaceholder`
+
+Layout:
+
+- `UserHeader`
+- `UserFooter`
+- `UserLayout`
+- `AdminSidebar`
+- `AdminHeader`
+- `AdminLayout`
+
+## Nguyên Tắc FE
+
+- Route page nên giữ mỏng, logic nằm trong component con.
+- Dữ liệu mock nên đặt trong `fe/lib` hoặc file data rõ ràng để thay API dễ.
+- Component map cần là client component vì Leaflet dùng `window`.
+- Giữ form responsive và có validation cơ bản.
+- Tất cả PR FE cần chạy:
+
+```bash
+npm --prefix fe run lint
+npm --prefix fe run build
+```
+
+## Module FE Nên Tách
+
+```text
+fe/components/
+  admin/
+  auth/
+  destinations/
+  map/
+  reviews/
+  route/
+  tours/
+  weather-traffic/
+```
+
+Không bắt buộc tạo hết ngay, nhưng khi một trang bắt đầu có logic thật thì nên tách component khỏi `page.tsx`.

--- a/docs/gis/overview.md
+++ b/docs/gis/overview.md
@@ -1,0 +1,53 @@
+# GIS Overview
+
+## Vai Trò GIS Trong Project
+
+GIS là lõi của hệ thống. Ứng dụng không chỉ hiển thị danh sách điểm du lịch mà phải gắn dữ liệu đó với tọa độ, lớp bản đồ, ranh giới, tuyến đường và thuộc tính địa lý.
+
+## Không Gian Triển Khai
+
+Phạm vi không gian:
+
+- Quảng Trị: di tích lịch sử, địa chỉ đỏ, tuyến sinh thái phía Tây, Cồn Cỏ.
+- Huế: quần thể di tích Cố đô, lăng tẩm, sông Hương, đầm phá, làng nghề.
+- Đà Nẵng: đô thị, biển, Sơn Trà, Ngũ Hành Sơn, điểm vui chơi, ẩm thực.
+
+## Lớp Dữ Liệu GIS
+
+| Nhóm | Lớp dữ liệu | Kiểu hình học | Mục đích |
+|---|---|---|---|
+| Basemap | OpenStreetMap/ArcGIS tiles | Raster/vector tile | Nền bản đồ. |
+| Province boundary | Ranh giới tỉnh/thành | Polygon | Lọc theo địa bàn, geofence. |
+| Tourist destination | Điểm du lịch | Point | Marker, popup, chi tiết POI. |
+| Service facility | Khách sạn, nhà hàng, bãi đỗ, y tế | Point | Dịch vụ hỗ trợ quanh điểm đến. |
+| Road network | Quốc lộ, tỉnh lộ, đường ven biển, đường mòn | LineString | Chỉ đường, định tuyến. |
+| Weather/traffic | Thời tiết, ùn tắc, trạng thái tuyến | Point/segment | Cảnh báo và hỗ trợ lịch trình. |
+
+## Hệ Tọa Độ
+
+Báo cáo nhắc tới VN-2000 cho chuẩn bản đồ Việt Nam và WGS84/EPSG:4326 cho dữ liệu web/GeoJSON.
+
+Khuyến nghị triển khai:
+
+- Lưu dữ liệu web map bằng `geometry(..., 4326)` trong PostGIS để dễ tích hợp Leaflet/OpenStreetMap.
+- Nếu có dữ liệu VN-2000/QGIS, chuẩn hóa/transform sang EPSG:4326 trước khi seed hoặc trả API.
+- Ghi rõ CRS của mọi file GeoJSON/Shapefile trong `docs/gis` hoặc metadata.
+
+## Định Tuyến
+
+Báo cáo chọn thuật toán Dijkstra cho tìm đường ngắn nhất.
+
+MVP có thể làm theo thứ tự:
+
+1. UI form chọn điểm bắt đầu/điểm đến.
+2. Tính khoảng cách thẳng hoặc gọi dịch vụ routing nếu chưa có road network.
+3. Khi có dữ liệu đường, mô hình hóa road network thành graph.
+4. Dijkstra hoặc thư viện routing/PostGIS/pgRouting nếu thời gian cho phép.
+
+## Advanced GIS Roadmap
+
+- Spatial query theo bán kính quanh vị trí hiện tại.
+- Heatmap mật độ điểm đến hoặc lượt tương tác.
+- Geofencing alert khi người dùng vào vùng cảnh báo.
+- Hidden Gems Discovery dựa trên khoảng cách, rating, độ phổ biến.
+- Offline map cache/PWA cho vùng sóng yếu.

--- a/docs/product/feature-coverage.md
+++ b/docs/product/feature-coverage.md
@@ -1,0 +1,74 @@
+# Feature Coverage
+
+File này đối chiếu báo cáo với source/issue hiện tại để trả lời câu hỏi: **đã đảm bảo tất cả chức năng cần thiết chưa?**
+
+## Kết Luận
+
+Đã cover đủ **core use-case** cần thiết cho một MVP WebGIS du lịch 2D.
+
+Chưa cover đầy đủ ở mức implementation riêng cho các tính năng nâng cao/sáng tạo trong báo cáo. Những phần đó nên được coi là phase 2 hoặc tạo issue riêng nếu muốn demo.
+
+## Core User Features
+
+| Chức năng trong báo cáo | Route hiện tại | Issue chính | Trạng thái coverage |
+|---|---|---|---|
+| Đăng ký | `/auth/register` | #11 | Covered MVP |
+| Đăng nhập | `/auth/login` | #11 | Covered MVP |
+| Xem bản đồ du lịch 2D | `/map` | #6 | Covered MVP |
+| Xem lớp dữ liệu | `/map/layers` | #6 | Covered MVP |
+| Tìm kiếm địa điểm | `/destinations` | #10 | Covered MVP |
+| Lọc địa điểm | `/destinations` | #10 | Covered MVP |
+| Xem chi tiết địa điểm | `/destinations/[id]` | #10 | Covered MVP |
+| Chỉ đường | `/route` | #10, #3, #9 | Covered MVP |
+| Xem thời tiết/giao thông | `/weather-traffic` | #10, #12, #3, #9 | Covered MVP |
+| Tạo tour | `/tours/create` | #11 | Covered MVP |
+| Lưu tour | `/tours/create` + API TourPlan | #11, #3, #9 | Covered MVP |
+| Đánh giá địa điểm | `/reviews` | #11, #12 | Covered MVP |
+
+## Core Admin Features
+
+| Chức năng trong báo cáo | Route hiện tại | Issue chính | Trạng thái coverage |
+|---|---|---|---|
+| Đăng nhập hệ thống quản trị | `/admin/login` | #12, #3 | Covered MVP |
+| Tổng quan quản trị | `/admin` | #12 | Covered MVP |
+| Quản lý điểm du lịch | `/admin/destinations` | #12, #3, #9 | Covered MVP |
+| Thêm điểm du lịch | `/admin/destinations/new` | #12, #3, #9 | Covered MVP |
+| Sửa điểm du lịch | `/admin/destinations/[id]/edit` | #12, #3, #9 | Covered MVP |
+| Xóa điểm du lịch | API/admin action | #12, #3, #9 | Covered MVP |
+| Quản lý dịch vụ hỗ trợ | `/admin/services` | #12, #3, #9 | Covered MVP |
+| Quản lý loại hình du lịch | `/admin/categories` | #12, #3, #9 | Covered MVP |
+| Quản lý thông báo | `/admin/notifications` | #12, #3, #9 | Covered MVP |
+| Cập nhật thời tiết | `/admin/weather` | #12, #3, #9 | Covered MVP |
+| Cập nhật giao thông | `/admin/traffic` | #12, #3, #9 | Covered MVP |
+| Quản lý đánh giá | `/admin/reviews` | #12, #3, #9 | Covered MVP |
+| Kiểm duyệt đánh giá | `/admin/reviews/[id]/moderate` | #12, #3, #9 | Covered MVP |
+
+## 12 Chức Năng Phạm Vi Báo Cáo
+
+| # | Chức năng | Coverage hiện tại | Ghi chú |
+|---|---|---|---|
+| 1 | Bản đồ 2D tương tác đa lớp | Covered MVP | #6 phụ trách map/layers. |
+| 2 | Chỉ đường & Smart Routing | Covered MVP | #10 UI, #3/#9 API/data. Dijkstra nâng cao có thể làm sau. |
+| 3 | Tìm kiếm không gian & bộ lọc | Covered MVP | #10. Spatial query theo bán kính nên thêm sau khi PostGIS ổn. |
+| 4 | Truy xuất thuộc tính POI | Covered MVP | #10 và #6 popup/detail. |
+| 5 | Bioclimatic overlays/cảnh báo | Partial | Có weather/traffic route, nhưng chưa có mô hình sinh khí hậu đầy đủ. |
+| 6 | Geofencing alerts | Roadmap | Chưa có route/issue riêng. Có thể mở rộng từ Notification + location. |
+| 7 | Interactive StoryMaps | Roadmap | Chưa có route/issue riêng. |
+| 8 | Geo-Gamification | Roadmap | Chưa có route/issue riêng. |
+| 9 | Hidden Gems Discovery | Partial/Roadmap | Có thể mở rộng trong search/recommendation ở #10. |
+| 10 | Deep Offline Mode | Roadmap | Cần PWA/offline cache issue riêng. |
+| 11 | Admin CRUD Dashboard | Covered MVP | #12 + #3/#9. |
+| 12 | Spatial Analytics/Export report | Roadmap | Dashboard có thể làm basic; heatmap/export cần issue riêng. |
+
+## Khuyến Nghị Cho Team
+
+Nếu mục tiêu là đồ án demo trong thời gian ngắn: giữ 6 issue hiện tại là đủ ở mức epic.
+
+Nếu mục tiêu là bám sát toàn bộ báo cáo, tạo thêm issue phase 2:
+
+- `[GIS] Spatial radius query bằng PostGIS`
+- `[GIS] Geofencing alerts prototype`
+- `[FE] StoryMaps tuyến di sản`
+- `[FE] Geo-Gamification nhiệm vụ địa lý`
+- `[FE/BE] PWA offline map cache`
+- `[Admin] Spatial analytics heatmap và export report`

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -1,0 +1,62 @@
+# Product Overview
+
+## Tên Và Phạm Vi
+
+Ứng dụng: **GIS Du lịch miền Trung**
+
+Đề tài: xây dựng ứng dụng WebGIS du lịch 2D cho khu vực **Quảng Trị - Huế - Đà Nẵng**.
+
+Hệ thống không đi theo hướng GIS 3D, point cloud, mô hình khối công trình, HBIM hoặc mô phỏng chi tiết di tích. Trọng tâm là bản đồ 2D, dữ liệu không gian, tra cứu du lịch và quản trị dữ liệu.
+
+## Bài Toán
+
+Báo cáo xác định các vấn đề chính:
+
+- Dữ liệu du lịch giữa Quảng Trị, Huế, Đà Nẵng còn phân mảnh.
+- Nền tảng bản đồ thương mại thiếu lớp dữ liệu chuyên đề du lịch địa phương.
+- Du lịch miền Trung phụ thuộc nhiều vào thời tiết, giao thông, môi trường.
+- Cách diễn giải di sản còn tĩnh, chưa tận dụng bản đồ kể chuyện và trải nghiệm tương tác.
+
+## Actor
+
+1. **Người dùng / Du khách**
+   - Xem bản đồ 2D.
+   - Tìm kiếm, lọc, xem chi tiết điểm du lịch.
+   - Chỉ đường, tạo tour, lưu tour.
+   - Xem thời tiết/giao thông.
+   - Đánh giá địa điểm.
+
+2. **Quản trị viên**
+   - Quản lý điểm du lịch.
+   - Quản lý dịch vụ hỗ trợ.
+   - Quản lý loại hình du lịch.
+   - Quản lý thông báo.
+   - Cập nhật thời tiết/giao thông.
+   - Quản lý và kiểm duyệt đánh giá.
+
+3. **Reviewer / Maintainer**
+   - Vai trò review code, kiểm tra PR, đảm bảo task đúng scope.
+   - Không nhận issue triển khai chính nếu đã thống nhất như hiện tại.
+
+## MVP Nên Hoàn Thành Trước
+
+MVP cần chứng minh được một WebGIS du lịch 2D hoạt động end-to-end:
+
+- Frontend có đủ route user/admin.
+- Backend có API rõ contract.
+- Database có schema và seed data tối thiểu.
+- Map hiển thị được điểm du lịch/dịch vụ/ranga giới hoặc lớp GeoJSON.
+- User xem, tìm, lọc, xem chi tiết, tạo tour, gửi đánh giá.
+- Admin CRUD dữ liệu chính.
+
+## Roadmap Nâng Cao
+
+Các mục này có trong báo cáo nhưng không nên trộn vào MVP nếu thời gian hạn chế:
+
+- Interactive StoryMaps.
+- Geo-Gamification.
+- Hidden Gems Discovery.
+- Geofencing Alerts.
+- Deep Offline Mode.
+- Heatmap/Spatial Analytics và xuất báo cáo.
+- Bioclimatic overlay đúng nghĩa chuyên sâu.

--- a/docs/team/workflow.md
+++ b/docs/team/workflow.md
@@ -1,0 +1,66 @@
+# Team Workflow
+
+## Branch
+
+Mỗi task nên có branch riêng:
+
+```text
+feature/<short-task-name>
+fix/<short-fix-name>
+docs/<short-doc-name>
+```
+
+Ví dụ:
+
+- `feature/map-layers`
+- `feature/admin-destinations`
+- `feature/postgis-schema`
+
+## Pull Request
+
+Mỗi PR cần có:
+
+- Link issue.
+- Summary thay đổi.
+- Screenshot nếu là FE.
+- API contract nếu là BE.
+- Checklist test/lint/build đã chạy.
+
+Reviewer chính hiện tại là `vanthinh26102005`, không nhận issue implementation chính.
+
+## Chia Mảng Hiện Tại
+
+| Mảng | Thành viên | Issue |
+|---|---|---|
+| BE API | Thoáng | #3 |
+| BE DB/PostGIS | Phước Thịnh | #9 |
+| FE Map/GIS layers | Vy | #6 |
+| FE Destinations/Route/Weather | Đạt | #10 |
+| FE Auth/Tour/Review | Hoàng Anh | #11 |
+| FE Admin | Bảo Thắng | #12 |
+
+## Quy Tắc Tránh Conflict
+
+- Người làm BE không sửa FE nếu không cần.
+- Người làm FE không sửa schema/API nếu chưa thống nhất.
+- Nếu cần sửa `fe/lib/routes.ts`, báo trước vì file này ảnh hưởng navigation toàn app.
+- Nếu cần đổi data shape API, cập nhật docs/backend và báo FE.
+- Không commit `node_modules`, `.next`, `.DS_Store`.
+
+## Agent/AI Folders
+
+Team có thể dùng `.agent/`, `.agents/`, `.claude/`, `.codex/` cho workflow hoặc skill local.
+
+Trước khi commit các folder đó:
+
+- Chỉ commit file instruction thật sự cần share.
+- Không commit token, key, cache, output tạm.
+- Nếu folder chỉ phục vụ máy cá nhân, đưa vào `.gitignore`.
+
+## Checklist PR Chung
+
+- [ ] Scope bám issue.
+- [ ] Không sửa file ngoài scope nếu không giải thích.
+- [ ] App chạy được sau khi pull.
+- [ ] Có cập nhật docs nếu đổi kiến trúc/API/route.
+- [ ] Không để console/debug log không cần thiết.


### PR DESCRIPTION
## Summary
- Add project docs extracted from the IE402 report and current source structure.
- Document feature coverage, including what is covered for MVP and what remains phase 2.
- Add GIS, data model, backend, frontend, workflow, and Codex context references.

## Notes
- Core user/admin WebGIS routes are covered at MVP scaffold/epic level.
- Advanced report features such as StoryMaps, geofencing, gamification, deep offline mode, and spatial analytics are marked as roadmap items.

## Test
- git diff --cached --check before commit.