### PR TITLE
feat(admin): implement admin dashboard and data management UI

### DIFF
--- a/fe/app/admin/categories/page.tsx
+++ b/fe/app/admin/categories/page.tsx
@@ -1,22 +1,144 @@
-import { DataTablePlaceholder } from "@/components/common/DataTablePlaceholder";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
+
+import { useState } from "react";
+import { Plus, Search, Edit, Trash2, FolderTree } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Input } from "@/components/common/Input";
+import { Card } from "@/components/common/Card";
+import { DataTable, Column, Action } from "@/components/admin/DataTable";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { mockCategories, type DestinationCategory } from "@/lib/admin-data";
 
 export default function AdminCategoriesPage() {
+  const [search, setSearch] = useState("");
+
+  const filteredData = mockCategories.filter((cat) => {
+    if (!search) return true;
+    return (
+      cat.name.toLowerCase().includes(search.toLowerCase()) ||
+      cat.description.toLowerCase().includes(search.toLowerCase())
+    );
+  });
+
+  const columns: Column<DestinationCategory>[] = [
+    {
+      key: "name",
+      header: "Tên loại hình",
+      width: "180px",
+      render: (row) => (
+        <div className="flex items-center gap-3">
+          <div
+            className="size-8 rounded-lg"
+            style={{ backgroundColor: row.color ? `${row.color}20` : "#f3f4f5" }}
+          >
+            <div
+              className="flex size-full items-center justify-center rounded-lg text-xs font-bold"
+              style={{ color: row.color || "#6b7280" }}
+            >
+              {row.name.charAt(0)}
+            </div>
+          </div>
+          <div>
+            <p className="font-medium text-slate-900">{row.name}</p>
+            <div
+              className="mt-0.5 h-1.5 w-12 rounded-full"
+              style={{ backgroundColor: row.color || "#e5e7eb" }}
+            />
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "description",
+      header: "Mô tả",
+      render: (row) => <p className="text-slate-600">{row.description}</p>,
+    },
+    {
+      key: "destinations_count",
+      header: "Số điểm",
+      width: "100px",
+      render: (row) => (
+        <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+          {row.destinations_count}
+        </span>
+      ),
+    },
+    {
+      key: "updated_at",
+      header: "Cập nhật",
+      width: "130px",
+      render: (row) => (
+        <span className="text-slate-500">
+          {new Date(row.updated_at).toLocaleDateString("vi-VN")}
+        </span>
+      ),
+    },
+  ];
+
+  const actions: Action<DestinationCategory>[] = [
+    {
+      label: "Sửa",
+      icon: Edit,
+      variant: "ghost",
+    },
+    {
+      label: "Xóa",
+      icon: Trash2,
+      variant: "destructive",
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Quản lý loại hình du lịch"
-      description="Trang quản lý danh mục loại hình cho điểm du lịch."
-      placeholder="Trang này là trang quản lý loại hình du lịch."
-      suggestions={[
-        "Kết nối bảng DestinationCategory.",
-        "Thêm form tạo và chỉnh sửa danh mục.",
-        "Đảm bảo tên loại hình không bị trùng.",
-      ]}
-    >
-      <DataTablePlaceholder
-        title="Table_Category"
-        columns={["Tên loại hình", "Mô tả", "Cập nhật", "Thao tác"]}
-      />
-    </PagePlaceholder>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Quản lý loại hình du lịch
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Quản lý danh mục loại hình cho điểm du lịch.
+          </p>
+        </div>
+        <Button>
+          <Plus className="mr-2 size-4" aria-hidden="true" />
+          Thêm loại hình
+        </Button>
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="relative lg:col-span-2">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+            <Input
+              placeholder="Tìm kiếm loại hình..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="flex items-center text-sm text-slate-500">
+            <FolderTree className="mr-1.5 size-4" aria-hidden="true" />
+            {filteredData.length} loại hình
+          </div>
+        </div>
+      </Card>
+
+      {filteredData.length === 0 ? (
+        <EmptyState
+          title="Không tìm thấy loại hình"
+          description="Thử thay đổi từ khóa tìm kiếm."
+          icon={FolderTree}
+          action={{ label: "Thêm loại hình" }}
+        />
+      ) : (
+        <DataTable
+          data={filteredData}
+          columns={columns}
+          actions={actions}
+          keyExtractor={(row) => row.id}
+          emptyMessage="Không có loại hình nào"
+        />
+      )}
+    </div>
   );
 }

--- a/fe/app/admin/destinations/[id]/edit/page.tsx
+++ b/fe/app/admin/destinations/[id]/edit/page.tsx
@@ -1,37 +1,40 @@
-import { Button } from "@/components/common/Button";
-import { Input } from "@/components/common/Input";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
-import { Select } from "@/components/common/Select";
-import { REGION_PROVINCES } from "@/lib/constants";
+import { DestinationForm } from "@/components/admin/DestinationForm";
+import { mockDestinations } from "@/lib/admin-data";
 
-export default function EditDestinationPage() {
-  return (
-    <PagePlaceholder
-      title="Sửa điểm du lịch"
-      description="Trang biểu mẫu cập nhật thông tin một điểm du lịch đã tồn tại."
-      placeholder="Trang này là trang sửa điểm du lịch."
-      suggestions={[
-        "Lấy id từ dynamic route để tải dữ liệu hiện có.",
-        "Tái sử dụng form với trang thêm điểm du lịch.",
-        "Gửi API cập nhật và xử lý trạng thái lưu.",
-      ]}
-    >
-      <div className="grid max-w-2xl gap-3 md:grid-cols-2">
-        <Input placeholder="Tên điểm du lịch" />
-        <Select
-          defaultValue=""
-          options={[
-            { label: "Chọn tỉnh/thành", value: "" },
-            ...REGION_PROVINCES.map((province) => ({
-              label: province,
-              value: province,
-            })),
-          ]}
-        />
-        <Input placeholder="Địa chỉ" />
-        <Input placeholder="Tọa độ" />
-        <Button className="md:col-span-2">Cập nhật điểm du lịch</Button>
+interface EditDestinationPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditDestinationPage({ params }: EditDestinationPageProps) {
+  const { id } = await params;
+  const destination = mockDestinations.find((d) => d.id === id);
+
+  if (!destination) {
+    return (
+      <div className="flex h-[50vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-slate-950">Không tìm thấy</h1>
+          <p className="mt-2 text-slate-600">Điểm du lịch không tồn tại.</p>
+        </div>
       </div>
-    </PagePlaceholder>
+    );
+  }
+
+  return (
+    <DestinationForm
+      initialData={{
+        name: destination.name,
+        province: destination.province,
+        category: destination.category,
+        address: destination.address,
+        latitude: destination.latitude.toString(),
+        longitude: destination.longitude.toString(),
+        ticket_price: destination.ticket_price.toString(),
+        open_time: destination.open_time,
+        close_time: destination.close_time,
+        description: destination.description,
+      }}
+      isEditing
+    />
   );
 }

--- a/fe/app/admin/destinations/new/page.tsx
+++ b/fe/app/admin/destinations/new/page.tsx
@@ -1,37 +1,5 @@
-import { Button } from "@/components/common/Button";
-import { Input } from "@/components/common/Input";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
-import { Select } from "@/components/common/Select";
-import { REGION_PROVINCES } from "@/lib/constants";
+import { DestinationForm } from "@/components/admin/DestinationForm";
 
 export default function NewDestinationPage() {
-  return (
-    <PagePlaceholder
-      title="Thêm điểm du lịch"
-      description="Trang biểu mẫu tạo mới một điểm du lịch trong hệ thống."
-      placeholder="Trang này là trang thêm điểm du lịch."
-      suggestions={[
-        "Tạo form đầy đủ theo schema TouristDestination.",
-        "Thêm chọn tọa độ trên bản đồ.",
-        "Kết nối API tạo mới dữ liệu.",
-      ]}
-    >
-      <div className="grid max-w-2xl gap-3 md:grid-cols-2">
-        <Input placeholder="Tên điểm du lịch" />
-        <Select
-          defaultValue=""
-          options={[
-            { label: "Chọn tỉnh/thành", value: "" },
-            ...REGION_PROVINCES.map((province) => ({
-              label: province,
-              value: province,
-            })),
-          ]}
-        />
-        <Input placeholder="Địa chỉ" />
-        <Input placeholder="Giá vé" />
-        <Button className="md:col-span-2">Lưu điểm du lịch</Button>
-      </div>
-    </PagePlaceholder>
-  );
+  return <DestinationForm />;
 }

--- a/fe/app/admin/destinations/page.tsx
+++ b/fe/app/admin/destinations/page.tsx
@@ -1,19 +1,176 @@
-import { DataTablePlaceholder } from "@/components/common/DataTablePlaceholder";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { Plus, Search, Edit, MapPinned } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Input } from "@/components/common/Input";
+import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { DataTable, Column, Action } from "@/components/admin/DataTable";
+import { StatusBadge, CategoryBadge } from "@/components/admin/StatusBadge";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { mockDestinations, type TouristDestination } from "@/lib/admin-data";
+import { REGION_PROVINCES } from "@/lib/constants";
 
 export default function AdminDestinationsPage() {
+  const [search, setSearch] = useState("");
+  const [province, setProvince] = useState("");
+  const [category, setCategory] = useState("");
+
+  const categories = useMemo(() => {
+    const cats = [...new Set(mockDestinations.map((d) => d.category))];
+    return cats.map((c) => ({ label: c, value: c }));
+  }, []);
+
+  const filteredData = useMemo(() => {
+    return mockDestinations.filter((dest) => {
+      const matchesSearch =
+        !search ||
+        dest.name.toLowerCase().includes(search.toLowerCase()) ||
+        dest.address.toLowerCase().includes(search.toLowerCase());
+      const matchesProvince = !province || dest.province === province;
+      const matchesCategory = !category || dest.category === category;
+      return matchesSearch && matchesProvince && matchesCategory;
+    });
+  }, [search, province, category]);
+
+  const columns: Column<TouristDestination>[] = [
+    {
+      key: "name",
+      header: "Tên điểm du lịch",
+      width: "220px",
+      render: (row) => (
+        <div>
+          <p className="font-medium text-slate-900">{row.name}</p>
+          <p className="mt-0.5 text-xs text-slate-500">{row.address}</p>
+        </div>
+      ),
+    },
+    {
+      key: "province",
+      header: "Tỉnh/Thành",
+      width: "120px",
+    },
+    {
+      key: "category",
+      header: "Loại hình",
+      width: "140px",
+      render: (row) => <CategoryBadge label={row.category} />,
+    },
+    {
+      key: "ticket_price",
+      header: "Giá vé",
+      width: "100px",
+      render: (row) => (
+        <span className="text-slate-700">
+          {row.ticket_price === 0 ? "Miễn phí" : `${row.ticket_price.toLocaleString()}đ`}
+        </span>
+      ),
+    },
+    {
+      key: "open_time",
+      header: "Giờ mở cửa",
+      width: "120px",
+      render: (row) => (
+        <span className="text-slate-600">
+          {row.open_time} - {row.close_time}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Trạng thái",
+      width: "110px",
+      render: (row) => {
+        const statusMap = {
+          active: { label: "Hoạt động", type: "success" as const },
+          inactive: { label: "Tạm dừng", type: "error" as const },
+          pending: { label: "Chờ duyệt", type: "warning" as const },
+        };
+        const status = statusMap[row.status];
+        return <StatusBadge status={status.type} label={status.label} />;
+      },
+    },
+  ];
+
+  const actions: Action<TouristDestination>[] = [
+    {
+      label: "Sửa",
+      icon: Edit,
+      href: (row) => `/admin/destinations/${row.id}/edit`,
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Quản lý điểm du lịch"
-      description="Trang danh sách và thao tác dữ liệu điểm du lịch."
-      placeholder="Trang này là trang quản lý điểm du lịch."
-      suggestions={[
-        "Kết nối bảng TouristDestination.",
-        "Thêm tìm kiếm, lọc tỉnh/thành và loại hình.",
-        "Điều hướng sang trang thêm/sửa điểm du lịch.",
-      ]}
-    >
-      <DataTablePlaceholder title="Table_Destination" />
-    </PagePlaceholder>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Quản lý điểm du lịch
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Danh sách và thao tác dữ liệu điểm du lịch trong hệ thống.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/admin/destinations/new">
+            <Plus className="mr-2 size-4" aria-hidden="true" />
+            Thêm điểm du lịch
+          </Link>
+        </Button>
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+            <Input
+              placeholder="Tìm kiếm điểm du lịch..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select
+            value={province}
+            onChange={(e) => setProvince(e.target.value)}
+            options={[
+              { label: "Tất cả tỉnh/thành", value: "" },
+              ...REGION_PROVINCES.map((p) => ({ label: p, value: p })),
+            ]}
+          />
+          <Select
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+            options={[{ label: "Tất cả loại hình", value: "" }, ...categories]}
+          />
+          <div className="flex items-center text-sm text-slate-500">
+            <MapPinned className="mr-1.5 size-4" aria-hidden="true" />
+            {filteredData.length} kết quả
+          </div>
+        </div>
+      </Card>
+
+      {filteredData.length === 0 ? (
+        <EmptyState
+          title="Không tìm thấy điểm du lịch"
+          description="Thử thay đổi từ khóa tìm kiếm hoặc bộ lọc."
+          icon={MapPinned}
+          action={{
+            label: "Thêm điểm du lịch",
+            href: "/admin/destinations/new",
+          }}
+        />
+      ) : (
+        <DataTable
+          data={filteredData}
+          columns={columns}
+          actions={actions}
+          keyExtractor={(row) => row.id}
+          emptyMessage="Không có điểm du lịch nào"
+        />
+      )}
+    </div>
   );
 }

--- a/fe/app/admin/notifications/page.tsx
+++ b/fe/app/admin/notifications/page.tsx
@@ -1,22 +1,188 @@
-import { DataTablePlaceholder } from "@/components/common/DataTablePlaceholder";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
+
+import { useState, useMemo } from "react";
+import { Plus, Search, Edit, Trash2, Bell, MapPin } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Input } from "@/components/common/Input";
+import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { DataTable, Column, Action } from "@/components/admin/DataTable";
+import { StatusBadge } from "@/components/admin/StatusBadge";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { mockNotifications, type Notification } from "@/lib/admin-data";
+
+const notificationTypeLabels: Record<Notification["type"], { label: string; color: string }> = {
+  info: { label: "Thông tin", color: "bg-blue-50 text-blue-700" },
+  warning: { label: "Cảnh báo", color: "bg-amber-50 text-amber-700" },
+  alert: { label: "Khẩn cấp", color: "bg-red-50 text-red-700" },
+  promotion: { label: "Khuyến mãi", color: "bg-emerald-50 text-emerald-700" },
+};
+
+const statusLabels: Record<Notification["status"], { label: string; type: "success" | "warning" | "error" | "pending" }> = {
+  active: { label: "Đang hiển thị", type: "success" },
+  inactive: { label: "Tạm ẩn", type: "warning" },
+  expired: { label: "Hết hạn", type: "error" },
+};
 
 export default function AdminNotificationsPage() {
+  const [search, setSearch] = useState("");
+  const [type, setType] = useState("");
+  const [status, setStatus] = useState("");
+
+  const filteredData = useMemo(() => {
+    return mockNotifications.filter((notif) => {
+      const matchesSearch =
+        !search ||
+        notif.title.toLowerCase().includes(search.toLowerCase()) ||
+        notif.content.toLowerCase().includes(search.toLowerCase());
+      const matchesType = !type || notif.type === type;
+      const matchesStatus = !status || notif.status === status;
+      return matchesSearch && matchesType && matchesStatus;
+    });
+  }, [search, type, status]);
+
+  const columns: Column<Notification>[] = [
+    {
+      key: "title",
+      header: "Tiêu đề",
+      width: "220px",
+      render: (row) => (
+        <div>
+          <p className="font-medium text-slate-900">{row.title}</p>
+          <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{row.content}</p>
+        </div>
+      ),
+    },
+    {
+      key: "type",
+      header: "Loại",
+      width: "120px",
+      render: (row) => {
+        const typeConfig = notificationTypeLabels[row.type];
+        return (
+          <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${typeConfig.color}`}>
+            {typeConfig.label}
+          </span>
+        );
+      },
+    },
+    {
+      key: "destination",
+      header: "Địa điểm",
+      width: "150px",
+      render: (row) =>
+        row.destination_name ? (
+          <div className="flex items-center gap-1.5 text-slate-600">
+            <MapPin className="size-3.5" aria-hidden="true" />
+            <span className="text-sm">{row.destination_name}</span>
+          </div>
+        ) : (
+          <span className="text-slate-400">Tất cả</span>
+        ),
+    },
+    {
+      key: "date_range",
+      header: "Thời gian",
+      width: "150px",
+      render: (row) => (
+        <div className="text-sm text-slate-600">
+          <p>{new Date(row.start_date).toLocaleDateString("vi-VN")}</p>
+          <p className="text-xs text-slate-400">- {new Date(row.end_date).toLocaleDateString("vi-VN")}</p>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Trạng thái",
+      width: "130px",
+      render: (row) => {
+        const statusConfig = statusLabels[row.status];
+        return <StatusBadge status={statusConfig.type} label={statusConfig.label} />;
+      },
+    },
+  ];
+
+  const actions: Action<Notification>[] = [
+    {
+      label: "Sửa",
+      icon: Edit,
+      variant: "ghost",
+    },
+    {
+      label: "Xóa",
+      icon: Trash2,
+      variant: "destructive",
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Quản lý thông báo"
-      description="Trang tạo, cập nhật và xóa thông báo liên quan đến điểm du lịch."
-      placeholder="Trang này là trang quản lý thông báo."
-      suggestions={[
-        "Kết nối bảng Notification.",
-        "Thêm chọn điểm du lịch liên quan.",
-        "Quản lý trạng thái đang hiển thị hoặc hết hiệu lực.",
-      ]}
-    >
-      <DataTablePlaceholder
-        title="Table_Notification"
-        columns={["Tiêu đề", "Loại", "Trạng thái", "Thao tác"]}
-      />
-    </PagePlaceholder>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Quản lý thông báo
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Tạo, cập nhật và quản lý thông báo liên quan đến điểm du lịch.
+          </p>
+        </div>
+        <Button>
+          <Plus className="mr-2 size-4" aria-hidden="true" />
+          Thêm thông báo
+        </Button>
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="relative lg:col-span-2">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+            <Input
+              placeholder="Tìm kiếm thông báo..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            options={[
+              { label: "Tất cả loại", value: "" },
+              { label: "Thông tin", value: "info" },
+              { label: "Cảnh báo", value: "warning" },
+              { label: "Khẩn cấp", value: "alert" },
+              { label: "Khuyến mãi", value: "promotion" },
+            ]}
+          />
+          <Select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            options={[
+              { label: "Tất cả trạng thái", value: "" },
+              { label: "Đang hiển thị", value: "active" },
+              { label: "Tạm ẩn", value: "inactive" },
+              { label: "Hết hạn", value: "expired" },
+            ]}
+          />
+        </div>
+      </Card>
+
+      {filteredData.length === 0 ? (
+        <EmptyState
+          title="Không tìm thấy thông báo"
+          description="Thử thay đổi từ khóa tìm kiếm hoặc bộ lọc."
+          icon={Bell}
+          action={{ label: "Thêm thông báo" }}
+        />
+      ) : (
+        <DataTable
+          data={filteredData}
+          columns={columns}
+          actions={actions}
+          keyExtractor={(row) => row.id}
+          emptyMessage="Không có thông báo nào"
+        />
+      )}
+    </div>
   );
 }

--- a/fe/app/admin/page.tsx
+++ b/fe/app/admin/page.tsx
@@ -1,28 +1,165 @@
-import { Card } from "@/components/common/Card";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
 
-const metrics = ["Điểm du lịch", "Dịch vụ hỗ trợ", "Đánh giá"];
+import { Card } from "@/components/common/Card";
+import { MapPinned, Store, MessageSquare, Bell, Clock, CheckCircle } from "lucide-react";
+import { getDashboardStats } from "@/lib/admin-data";
 
 export default function AdminDashboardPage() {
+  const stats = getDashboardStats();
+
+  const statCards = [
+    {
+      title: "Điểm du lịch",
+      value: stats.destinations,
+      subValue: `${stats.activeDestinations} đang hoạt động`,
+      icon: MapPinned,
+      color: "text-blue-600",
+      bgColor: "bg-blue-50",
+      borderColor: "border-blue-200",
+    },
+    {
+      title: "Dịch vụ hỗ trợ",
+      value: stats.services,
+      subValue: "Khách sạn, nhà hàng, tiện ích",
+      icon: Store,
+      color: "text-teal-600",
+      bgColor: "bg-teal-50",
+      borderColor: "border-teal-200",
+    },
+    {
+      title: "Đánh giá",
+      value: stats.reviews,
+      subValue: `${stats.pendingReviews} đang chờ duyệt`,
+      icon: MessageSquare,
+      color: "text-amber-600",
+      bgColor: "bg-amber-50",
+      borderColor: "border-amber-200",
+    },
+    {
+      title: "Thông báo",
+      value: stats.notifications,
+      subValue: "Đang hiển thị",
+      icon: Bell,
+      color: "text-emerald-600",
+      bgColor: "bg-emerald-50",
+      borderColor: "border-emerald-200",
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Tổng quan quản trị"
-      description="Dashboard tổng quan cho quản trị viên theo dõi dữ liệu hệ thống."
-      placeholder="Trang này là trang tổng quan quản trị."
-      suggestions={[
-        "Hiển thị số lượng điểm du lịch, dịch vụ, đánh giá.",
-        "Thêm biểu đồ thống kê theo tỉnh/thành.",
-        "Gắn API thống kê khi backend hoàn thiện.",
-      ]}
-    >
-      <div className="grid gap-3 sm:grid-cols-3">
-        {metrics.map((metric) => (
-          <Card key={metric} className="p-4">
-            <p className="text-sm font-semibold text-slate-900">{metric}</p>
-            <p className="mt-2 text-2xl font-semibold text-blue-700">--</p>
-          </Card>
-        ))}
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+          Tổng quan quản trị
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Dashboard tổng quan cho quản trị viên theo dõi dữ liệu hệ thống.
+        </p>
       </div>
-    </PagePlaceholder>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {statCards.map((stat) => {
+          const Icon = stat.icon;
+          return (
+            <Card
+              key={stat.title}
+              className={`relative overflow-hidden border ${stat.borderColor} p-5 transition-shadow hover:shadow-md`}
+            >
+              <div className="flex items-start justify-between">
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-slate-600">{stat.title}</p>
+                  <p className="text-3xl font-bold text-slate-950">{stat.value}</p>
+                  <p className="text-xs text-slate-500">{stat.subValue}</p>
+                </div>
+                <div className={`rounded-lg p-2.5 ${stat.bgColor}`}>
+                  <Icon className={`size-5 ${stat.color}`} aria-hidden="true" />
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="p-5">
+          <h2 className="text-base font-semibold text-slate-950">Hoạt động gần đây</h2>
+          <div className="mt-4 space-y-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-blue-100 p-1.5">
+                <CheckCircle className="size-3.5 text-blue-600" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-700">
+                  Đánh giá của <span className="font-medium">Nguyễn Văn Minh</span> đã được duyệt
+                </p>
+                <p className="mt-0.5 text-xs text-slate-500">Đại Nội Huế</p>
+              </div>
+              <span className="text-xs text-slate-400">2 giờ trước</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-emerald-100 p-1.5">
+                <MapPinned className="size-3.5 text-emerald-600" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-700">
+                  Thêm mới điểm du lịch <span className="font-medium">Đèo Hải Vân</span>
+                </p>
+                <p className="mt-0.5 text-xs text-slate-500">Huế</p>
+              </div>
+              <span className="text-xs text-slate-400">5 giờ trước</span>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-amber-100 p-1.5">
+                <Clock className="size-3.5 text-amber-600" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-700">
+                  <span className="font-medium">2 đánh giá</span> đang chờ kiểm duyệt
+                </p>
+                <p className="mt-0.5 text-xs text-slate-500">Cần xử lý</p>
+              </div>
+              <span className="text-xs text-slate-400">1 ngày trước</span>
+            </div>
+          </div>
+        </Card>
+
+        <Card className="p-5">
+          <h2 className="text-base font-semibold text-slate-950">Thống kê nhanh</h2>
+          <div className="mt-4 space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-slate-600">Tỷ lệ duyệt đánh giá</span>
+              <span className="text-sm font-semibold text-emerald-600">80%</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+              <div className="h-full w-4/5 rounded-full bg-emerald-500" />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-slate-600">Điểm du lịch hoạt động</span>
+              <span className="text-sm font-semibold text-blue-600">
+                {Math.round((stats.activeDestinations / stats.destinations) * 100)}%
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+              <div
+                className="h-full rounded-full bg-blue-500"
+                style={{ width: `${(stats.activeDestinations / stats.destinations) * 100}%` }}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-slate-600">Đánh giá chờ xử lý</span>
+              <span className="text-sm font-semibold text-amber-600">{stats.pendingReviews}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+              <div
+                className="h-full rounded-full bg-amber-500"
+                style={{ width: `${(stats.pendingReviews / stats.reviews) * 100}%` }}
+              />
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
   );
 }

--- a/fe/app/admin/reviews/[id]/moderate/page.tsx
+++ b/fe/app/admin/reviews/[id]/moderate/page.tsx
@@ -1,29 +1,245 @@
+"use client";
+
+import { useState, use } from "react";
+import Link from "next/link";
+import { Check, ArrowLeft, EyeOff, Trash2, MapPinned, User, Clock, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/common/Button";
 import { Card } from "@/components/common/Card";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+import { RatingBadge, StatusBadge } from "@/components/admin/StatusBadge";
+import { mockReviews, type Review } from "@/lib/admin-data";
 
-export default function ModerateReviewPage() {
-  return (
-    <PagePlaceholder
-      title="Kiểm duyệt đánh giá"
-      description="Trang kiểm tra nội dung đánh giá trước khi hiển thị hoặc xử lý vi phạm."
-      placeholder="Trang này là trang kiểm duyệt đánh giá."
-      suggestions={[
-        "Lấy id từ dynamic route để tải nội dung đánh giá.",
-        "Thêm hành động duyệt, ẩn hoặc xóa đánh giá.",
-        "Ghi lại trạng thái kiểm duyệt.",
-      ]}
-    >
-      <Card className="space-y-3 p-4">
-        <p className="text-sm font-semibold text-slate-900">Review detail placeholder</p>
-        <p className="text-sm text-slate-600">
-          Nội dung đánh giá sẽ được hiển thị tại đây sau khi có API.
-        </p>
-        <div className="flex flex-wrap gap-3">
-          <Button>Duyệt</Button>
-          <Button className="bg-slate-700 hover:bg-slate-800">Ẩn đánh giá</Button>
+interface ModerateReviewPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ModerateReviewPage({ params }: ModerateReviewPageProps) {
+  const { id } = use(params);
+  const [currentStatus, setCurrentStatus] = useState<Review["status"] | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const review = mockReviews.find((r) => r.id === id);
+
+  if (!review) {
+    return (
+      <div className="flex h-[50vh] items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-slate-950">Không tìm thấy</h1>
+          <p className="mt-2 text-slate-600">Đánh giá không tồn tại.</p>
+          <Button asChild className="mt-4">
+            <Link href="/admin/reviews">Quay lại</Link>
+          </Button>
         </div>
-      </Card>
-    </PagePlaceholder>
+      </div>
+    );
+  }
+
+  const displayReview = {
+    ...review,
+    status: currentStatus || review.status,
+  };
+
+const statusLabels = {
+  approved: { label: "Đã duyệt", type: "success" as const },
+  pending: { label: "Chờ duyệt", type: "warning" as const },
+  hidden: { label: "Đã ẩn", type: "pending" as const },
+  rejected: { label: "Từ chối", type: "error" as const },
+} as const;
+
+  const handleAction = async (action: "approve" | "hide" | "reject") => {
+    setActionLoading(action);
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    switch (action) {
+      case "approve":
+        setCurrentStatus("approved");
+        break;
+      case "hide":
+        setCurrentStatus("hidden");
+        break;
+      case "reject":
+        setCurrentStatus("rejected");
+        break;
+    }
+
+    setActionLoading(null);
+  };
+
+  const isSuspiciousContent = review.content.length > 0 &&
+    (review.content === review.content.toUpperCase() && review.content.length > 50 ||
+     review.content.includes("PHẢN ĐỘNG") ||
+     review.content.includes("CỘNG SẢN"));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin/reviews">
+            <ArrowLeft className="mr-2 size-4" aria-hidden="true" />
+            Quay lại
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Kiểm duyệt đánh giá
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Kiểm tra nội dung đánh giá trước khi hiển thị hoặc xử lý vi phạm.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          <Card className="p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100">
+                  <User className="size-5 text-slate-500" aria-hidden="true" />
+                </div>
+                <div>
+                  <p className="font-semibold text-slate-900">{displayReview.user_name}</p>
+                  <p className="text-sm text-slate-500">ID: {displayReview.user_id}</p>
+                </div>
+              </div>
+              <StatusBadge
+                status={statusLabels[displayReview.status].type}
+                label={statusLabels[displayReview.status].label}
+              />
+            </div>
+
+            <div className="mt-4 flex items-center gap-4">
+              <div className="flex items-center gap-1.5">
+                <MapPinned className="size-4 text-slate-400" aria-hidden="true" />
+                <span className="font-medium text-slate-700">{displayReview.destination_name}</span>
+              </div>
+              <RatingBadge score={displayReview.rating} />
+            </div>
+
+            {isSuspiciousContent && (
+              <div className="mt-4 flex items-start gap-2 rounded-lg bg-red-50 p-4 border border-red-200">
+                <AlertTriangle className="size-5 text-red-600 mt-0.5" aria-hidden="true" />
+                <div>
+                  <p className="font-medium text-red-800">Cảnh báo nội dung đáng nghi</p>
+                  <p className="text-sm text-red-700 mt-1">
+                    Đánh giá này có thể chứa nội dung vi phạm hoặc spam. Hãy kiểm tra kỹ trước khi duyệt.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <div className="mt-4 rounded-lg bg-slate-50 p-4">
+              <p className="text-slate-700 whitespace-pre-wrap">{displayReview.content}</p>
+            </div>
+
+            <div className="mt-4 flex items-center gap-4 text-sm text-slate-500">
+              <div className="flex items-center gap-1.5">
+                <Clock className="size-4" aria-hidden="true" />
+                <span>{new Date(displayReview.created_at).toLocaleString("vi-VN")}</span>
+              </div>
+              {displayReview.updated_at !== displayReview.created_at && (
+                <div className="flex items-center gap-1.5">
+                  <span>Cập nhật: {new Date(displayReview.updated_at).toLocaleString("vi-VN")}</span>
+                </div>
+              )}
+            </div>
+          </Card>
+
+          <Card className="p-6">
+            <h2 className="text-base font-semibold text-slate-950">Hành động</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Chọn hành động phù hợp với nội dung đánh giá này.
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-3">
+              <Button
+                onClick={() => handleAction("approve")}
+                disabled={actionLoading !== null || displayReview.status === "approved"}
+                className="bg-emerald-600 hover:bg-emerald-700"
+              >
+                {actionLoading === "approve" ? (
+                  "Đang xử lý..."
+                ) : (
+                  <>
+                    <Check className="mr-2 size-4" aria-hidden="true" />
+                    Duyệt đánh giá
+                  </>
+                )}
+              </Button>
+
+              <Button
+                onClick={() => handleAction("hide")}
+                disabled={actionLoading !== null || displayReview.status === "hidden"}
+                variant="outline"
+              >
+                {actionLoading === "hide" ? (
+                  "Đang xử lý..."
+                ) : (
+                  <>
+                    <EyeOff className="mr-2 size-4" aria-hidden="true" />
+                    Ẩn đánh giá
+                  </>
+                )}
+              </Button>
+
+              <Button
+                onClick={() => handleAction("reject")}
+                disabled={actionLoading !== null || displayReview.status === "rejected"}
+                variant="outline"
+                className="text-red-600 hover:bg-red-50 hover:text-red-700 border-red-200 hover:border-red-300"
+              >
+                {actionLoading === "reject" ? (
+                  "Đang xử lý..."
+                ) : (
+                  <>
+                    <Trash2 className="mr-2 size-4" aria-hidden="true" />
+                    Từ chối
+                  </>
+                )}
+              </Button>
+            </div>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <Card className="p-6">
+            <h2 className="text-base font-semibold text-slate-950">Thông tin đánh giá</h2>
+            <div className="mt-4 space-y-3">
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500">ID đánh giá</span>
+                <span className="font-mono text-slate-700">{displayReview.id}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500">Điểm số</span>
+                <span className="font-medium text-slate-700">{displayReview.rating}/5</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-slate-500">Ngày tạo</span>
+                <span className="text-slate-700">
+                  {new Date(displayReview.created_at).toLocaleDateString("vi-VN")}
+                </span>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="p-6">
+            <h2 className="text-base font-semibold text-slate-950">Hướng dẫn</h2>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600">
+              <li className="flex items-start gap-2">
+                <Check className="size-4 text-emerald-500 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>Duyệt đánh giá tích cực, có nội dung phù hợp</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <EyeOff className="size-4 text-amber-500 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>Ẩn đánh giá vi phạm nhẹ, spam hoặc không phù hợp</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <Trash2 className="size-4 text-red-500 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>Từ chối đánh giá chứa nội dung phản động, thô tục</span>
+              </li>
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/fe/app/admin/reviews/page.tsx
+++ b/fe/app/admin/reviews/page.tsx
@@ -1,22 +1,168 @@
-import { DataTablePlaceholder } from "@/components/common/DataTablePlaceholder";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
+
+import { useState, useMemo } from "react";
+import { Search, Eye, MapPinned, MessageSquare } from "lucide-react";
+import { Input } from "@/components/common/Input";
+import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { DataTable, Column, Action } from "@/components/admin/DataTable";
+import { StatusBadge, RatingBadge } from "@/components/admin/StatusBadge";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { mockReviews, type Review } from "@/lib/admin-data";
+
+const statusLabels = {
+  approved: { label: "Đã duyệt", type: "success" as const },
+  pending: { label: "Chờ duyệt", type: "warning" as const },
+  hidden: { label: "Đã ẩn", type: "pending" as const },
+  rejected: { label: "Từ chối", type: "error" as const },
+} as const;
 
 export default function AdminReviewsPage() {
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState("");
+
+  const pendingCount = mockReviews.filter((r) => r.status === "pending").length;
+
+  const filteredData = useMemo(() => {
+    return mockReviews.filter((review) => {
+      const matchesSearch =
+        !search ||
+        review.user_name.toLowerCase().includes(search.toLowerCase()) ||
+        review.destination_name.toLowerCase().includes(search.toLowerCase()) ||
+        review.content.toLowerCase().includes(search.toLowerCase());
+      const matchesStatus = !status || review.status === status;
+      return matchesSearch && matchesStatus;
+    });
+  }, [search, status]);
+
+  const columns: Column<Review>[] = [
+    {
+      key: "user",
+      header: "Người đánh giá",
+      width: "160px",
+      render: (row) => (
+        <div>
+          <p className="font-medium text-slate-900">{row.user_name}</p>
+          <p className="mt-0.5 text-xs text-slate-500">ID: {row.user_id}</p>
+        </div>
+      ),
+    },
+    {
+      key: "destination",
+      header: "Địa điểm",
+      width: "160px",
+      render: (row) => (
+        <div className="flex items-center gap-1.5">
+          <MapPinned className="size-3.5 text-slate-400" aria-hidden="true" />
+          <span className="text-slate-700">{row.destination_name}</span>
+        </div>
+      ),
+    },
+    {
+      key: "rating",
+      header: "Điểm",
+      width: "80px",
+      render: (row) => <RatingBadge score={row.rating} />,
+    },
+    {
+      key: "content",
+      header: "Nội dung",
+      render: (row) => (
+        <p className="line-clamp-2 max-w-md text-sm text-slate-600">{row.content}</p>
+      ),
+    },
+    {
+      key: "status",
+      header: "Trạng thái",
+      width: "110px",
+      render: (row) => {
+        const statusConfig = statusLabels[row.status];
+        return <StatusBadge status={statusConfig.type} label={statusConfig.label} />;
+      },
+    },
+    {
+      key: "created_at",
+      header: "Ngày",
+      width: "100px",
+      render: (row) => (
+        <span className="text-slate-500">
+          {new Date(row.created_at).toLocaleDateString("vi-VN")}
+        </span>
+      ),
+    },
+  ];
+
+  const actions: Action<Review>[] = [
+    {
+      label: "Kiểm duyệt",
+      icon: Eye,
+      href: (row) => `/admin/reviews/${row.id}/moderate`,
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Quản lý đánh giá"
-      description="Trang theo dõi, lọc và xử lý đánh giá của người dùng."
-      placeholder="Trang này là trang quản lý đánh giá."
-      suggestions={[
-        "Kết nối bảng Review.",
-        "Thêm lọc theo địa điểm và điểm số.",
-        "Điều hướng sang trang kiểm duyệt từng đánh giá.",
-      ]}
-    >
-      <DataTablePlaceholder
-        title="Table_Review"
-        columns={["Người đánh giá", "Địa điểm", "Điểm", "Thao tác"]}
-      />
-    </PagePlaceholder>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Quản lý đánh giá
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Theo dõi, lọc và kiểm duyệt đánh giá của người dùng.
+          </p>
+        </div>
+        {pendingCount > 0 && (
+          <div className="inline-flex items-center gap-2 rounded-full bg-amber-50 px-4 py-2 text-sm font-medium text-amber-800 border border-amber-200">
+            <MessageSquare className="size-4" aria-hidden="true" />
+            {pendingCount} đánh giá chờ kiểm duyệt
+          </div>
+        )}
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="relative lg:col-span-2">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+            <Input
+              placeholder="Tìm kiếm đánh giá..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            options={[
+              { label: "Tất cả trạng thái", value: "" },
+              { label: "Chờ duyệt", value: "pending" },
+              { label: "Đã duyệt", value: "approved" },
+              { label: "Đã ẩn", value: "hidden" },
+              { label: "Từ chối", value: "rejected" },
+            ]}
+          />
+          <div className="flex items-center text-sm text-slate-500">
+            <MessageSquare className="mr-1.5 size-4" aria-hidden="true" />
+            {filteredData.length} đánh giá
+          </div>
+        </div>
+      </Card>
+
+      {filteredData.length === 0 ? (
+        <EmptyState
+          title="Không tìm thấy đánh giá"
+          description="Thử thay đổi từ khóa tìm kiếm hoặc bộ lọc."
+          icon={MessageSquare}
+        />
+      ) : (
+        <DataTable
+          data={filteredData}
+          columns={columns}
+          actions={actions}
+          keyExtractor={(row) => row.id}
+          emptyMessage="Không có đánh giá nào"
+        />
+      )}
+    </div>
   );
 }

--- a/fe/app/admin/services/page.tsx
+++ b/fe/app/admin/services/page.tsx
@@ -1,19 +1,186 @@
-import { DataTablePlaceholder } from "@/components/common/DataTablePlaceholder";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
+"use client";
+
+import { useState, useMemo } from "react";
+import { Plus, Search, Edit, Store, Trash2 } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Input } from "@/components/common/Input";
+import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { DataTable, Column, Action } from "@/components/admin/DataTable";
+import { StatusBadge } from "@/components/admin/StatusBadge";
+import { EmptyState } from "@/components/admin/EmptyState";
+import { mockServices, type ServiceFacility } from "@/lib/admin-data";
+import { REGION_PROVINCES } from "@/lib/constants";
+
+const serviceTypeLabels: Record<ServiceFacility["type"], string> = {
+  hotel: "Khách sạn",
+  restaurant: "Nhà hàng",
+  parking: "Bãi đỗ xe",
+  medical: "Y tế",
+  toilet: "Nhà vệ sinh",
+  atm: "ATM",
+  gas_station: "Trạm xăng",
+};
+
+const serviceTypeColors: Record<ServiceFacility["type"], { bg: string; text: string }> = {
+  hotel: { bg: "bg-blue-50", text: "text-blue-700" },
+  restaurant: { bg: "bg-orange-50", text: "text-orange-700" },
+  parking: { bg: "bg-slate-50", text: "text-slate-700" },
+  medical: { bg: "bg-red-50", text: "text-red-700" },
+  toilet: { bg: "bg-teal-50", text: "text-teal-700" },
+  atm: { bg: "bg-emerald-50", text: "text-emerald-700" },
+  gas_station: { bg: "bg-amber-50", text: "text-amber-700" },
+};
 
 export default function AdminServicesPage() {
+  const [search, setSearch] = useState("");
+  const [province, setProvince] = useState("");
+  const [serviceType, setServiceType] = useState("");
+
+  const serviceTypes = useMemo(() => {
+    const types = [...new Set(mockServices.map((s) => s.type))];
+    return types.map((t) => ({ label: serviceTypeLabels[t], value: t }));
+  }, []);
+
+  const filteredData = useMemo(() => {
+    return mockServices.filter((svc) => {
+      const matchesSearch =
+        !search ||
+        svc.name.toLowerCase().includes(search.toLowerCase()) ||
+        svc.address.toLowerCase().includes(search.toLowerCase());
+      const matchesProvince = !province || svc.province === province;
+      const matchesType = !serviceType || svc.type === serviceType;
+      return matchesSearch && matchesProvince && matchesType;
+    });
+  }, [search, province, serviceType]);
+
+  const columns: Column<ServiceFacility>[] = [
+    {
+      key: "name",
+      header: "Tên dịch vụ",
+      width: "220px",
+      render: (row) => (
+        <div>
+          <p className="font-medium text-slate-900">{row.name}</p>
+          <p className="mt-0.5 text-xs text-slate-500">{row.address}</p>
+        </div>
+      ),
+    },
+    {
+      key: "type",
+      header: "Loại dịch vụ",
+      width: "130px",
+      render: (row) => (
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${serviceTypeColors[row.type].bg} ${serviceTypeColors[row.type].text}`}
+        >
+          {serviceTypeLabels[row.type]}
+        </span>
+      ),
+    },
+    {
+      key: "province",
+      header: "Tỉnh/Thành",
+      width: "120px",
+    },
+    {
+      key: "phone",
+      header: "Số điện thoại",
+      width: "130px",
+      render: (row) => <span className="text-slate-600">{row.phone || "-"}</span>,
+    },
+    {
+      key: "status",
+      header: "Trạng thái",
+      width: "110px",
+      render: (row) => {
+        const statusMap = {
+          active: { label: "Hoạt động", type: "success" as const },
+          inactive: { label: "Tạm dừng", type: "error" as const },
+        };
+        const status = statusMap[row.status];
+        return <StatusBadge status={status.type} label={status.label} />;
+      },
+    },
+  ];
+
+  const actions: Action<ServiceFacility>[] = [
+    {
+      label: "Sửa",
+      icon: Edit,
+      variant: "ghost",
+    },
+    {
+      label: "Xóa",
+      icon: Trash2,
+      variant: "destructive",
+    },
+  ];
+
   return (
-    <PagePlaceholder
-      title="Quản lý dịch vụ hỗ trợ"
-      description="Trang quản lý khách sạn, nhà hàng, bãi đỗ xe, y tế và tiện ích liên quan."
-      placeholder="Trang này là trang quản lý dịch vụ hỗ trợ."
-      suggestions={[
-        "Kết nối bảng ServiceFacility.",
-        "Thêm bộ lọc loại dịch vụ và tỉnh/thành.",
-        "Chuẩn bị form thêm/sửa dịch vụ hỗ trợ.",
-      ]}
-    >
-      <DataTablePlaceholder title="Table_Service" />
-    </PagePlaceholder>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            Quản lý dịch vụ hỗ trợ
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Quản lý khách sạn, nhà hàng, bãi đỗ xe, y tế và tiện ích liên quan.
+          </p>
+        </div>
+        <Button>
+          <Plus className="mr-2 size-4" aria-hidden="true" />
+          Thêm dịch vụ
+        </Button>
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
+            <Input
+              placeholder="Tìm kiếm dịch vụ..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <Select
+            value={province}
+            onChange={(e) => setProvince(e.target.value)}
+            options={[
+              { label: "Tất cả tỉnh/thành", value: "" },
+              ...REGION_PROVINCES.map((p) => ({ label: p, value: p })),
+            ]}
+          />
+          <Select
+            value={serviceType}
+            onChange={(e) => setServiceType(e.target.value)}
+            options={[{ label: "Tất cả loại dịch vụ", value: "" }, ...serviceTypes]}
+          />
+          <div className="flex items-center text-sm text-slate-500">
+            <Store className="mr-1.5 size-4" aria-hidden="true" />
+            {filteredData.length} kết quả
+          </div>
+        </div>
+      </Card>
+
+      {filteredData.length === 0 ? (
+        <EmptyState
+          title="Không tìm thấy dịch vụ"
+          description="Thử thay đổi từ khóa tìm kiếm hoặc bộ lọc."
+          icon={Store}
+          action={{ label: "Thêm dịch vụ" }}
+        />
+      ) : (
+        <DataTable
+          data={filteredData}
+          columns={columns}
+          actions={actions}
+          keyExtractor={(row) => row.id}
+          emptyMessage="Không có dịch vụ nào"
+        />
+      )}
+    </div>
   );
 }

--- a/fe/app/admin/traffic/page.tsx
+++ b/fe/app/admin/traffic/page.tsx
@@ -1,38 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import { Car, RefreshCw, MapPin, AlertTriangle, AlertCircle, CheckCircle, Ban } from "lucide-react";
 import { Button } from "@/components/common/Button";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
 import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { mockTraffic, type TrafficData } from "@/lib/admin-data";
+import { cn } from "@/lib/utils";
+
+const congestionConfig: Record<TrafficData["congestion_level"], { label: string; icon: typeof CheckCircle; color: string; bgColor: string }> = {
+  low: { label: "Thông thoáng", icon: CheckCircle, color: "text-emerald-600", bgColor: "bg-emerald-50" },
+  medium: { label: "Ùn ứ nhẹ", icon: AlertCircle, color: "text-amber-600", bgColor: "bg-amber-50" },
+  high: { label: "Kẹt xe", icon: AlertTriangle, color: "text-red-600", bgColor: "bg-red-50" },
+  blocked: { label: "Đường bị chặn", icon: Ban, color: "text-red-800", bgColor: "bg-red-100" },
+};
 
 export default function AdminTrafficPage() {
+  const [selectedRoad, setSelectedRoad] = useState("");
+  const [formData, setFormData] = useState({
+    congestion_level: "",
+    description: "",
+  });
+  const [loading, setLoading] = useState(false);
+
+  const selectedTraffic = mockTraffic.find((t) => t.id === selectedRoad);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setLoading(false);
+    alert("Cập nhật giao thông thành công!");
+  };
+
   return (
-    <PagePlaceholder
-      title="Cập nhật dữ liệu giao thông"
-      description="Trang nhập hoặc đồng bộ tình trạng giao thông theo điểm/khu vực."
-      placeholder="Trang này là trang cập nhật dữ liệu giao thông."
-      suggestions={[
-        "Kết nối bảng TrafficInfo.",
-        "Đồng bộ dữ liệu từ API giao thông nếu có.",
-        "Hiển thị mức ùn tắc và trạng thái tuyến đường.",
-      ]}
-    >
-      <div className="grid max-w-2xl gap-3 md:grid-cols-3">
-        <Select
-          defaultValue=""
-          options={[
-            { label: "Chọn khu vực", value: "" },
-            { label: "Quốc lộ 1A", value: "ql1a" },
-          ]}
-        />
-        <Select
-          defaultValue=""
-          options={[
-            { label: "Mức ùn tắc", value: "" },
-            { label: "Thấp", value: "low" },
-            { label: "Trung bình", value: "medium" },
-            { label: "Cao", value: "high" },
-          ]}
-        />
-        <Button>Cập nhật</Button>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+          Cập nhật dữ liệu giao thông
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Nhập hoặc đồng bộ tình trạng giao thông theo khu vực.
+        </p>
       </div>
-    </PagePlaceholder>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Thông tin giao thông
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="road" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Tuyến đường / Khu vực
+                </label>
+                <Select
+                  id="road"
+                  value={selectedRoad}
+                  onChange={(e) => setSelectedRoad(e.target.value)}
+                  options={[
+                    { label: "Chọn tuyến đường", value: "" },
+                    ...mockTraffic.map((t) => ({
+                      label: t.road_name,
+                      value: t.id,
+                    })),
+                  ]}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="congestion_level" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Mức ùn tắc
+                </label>
+                <Select
+                  id="congestion_level"
+                  value={formData.congestion_level}
+                  onChange={(e) =>
+                    setFormData((prev) => ({ ...prev, congestion_level: e.target.value }))
+                  }
+                  options={[
+                    { label: "Chọn mức ùn tắc", value: "" },
+                    { label: "Thông thoáng", value: "low" },
+                    { label: "Ùn ứ nhẹ", value: "medium" },
+                    { label: "Kẹt xe", value: "high" },
+                    { label: "Đường bị chặn", value: "blocked" },
+                  ]}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="description" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Mô tả (tùy chọn)
+                </label>
+                <textarea
+                  id="description"
+                  placeholder="Thêm mô tả về tình trạng giao thông..."
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData((prev) => ({ ...prev, description: e.target.value }))
+                  }
+                  rows={3}
+                  className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-100"
+                />
+              </div>
+            </div>
+
+            <div className="mt-6 flex gap-3">
+              <Button type="submit" disabled={loading || !selectedRoad}>
+                {loading ? (
+                  "Đang cập nhật..."
+                ) : (
+                  <>
+                    <RefreshCw className="mr-2 size-4" aria-hidden="true" />
+                    Cập nhật giao thông
+                  </>
+                )}
+              </Button>
+            </div>
+          </Card>
+        </form>
+
+        <div className="space-y-4">
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Tình trạng hiện tại
+            </h2>
+            {selectedTraffic ? (
+              <div className="space-y-4">
+                {(() => {
+                  const config = congestionConfig[selectedTraffic.congestion_level];
+                  const CongestionIcon = config.icon;
+                  return (
+                    <>
+                      <div className="flex items-center gap-3">
+                        <div className={cn("rounded-full p-3", config.bgColor)}>
+                          <CongestionIcon className={cn("size-6", config.color)} aria-hidden="true" />
+                        </div>
+                        <div>
+                          <p className="text-sm font-semibold text-slate-900">
+                            {selectedTraffic.road_name}
+                          </p>
+                          <p className={cn("text-sm font-medium", config.color)}>
+                            {config.label}
+                          </p>
+                        </div>
+                      </div>
+                      {selectedTraffic.description && (
+                        <p className="text-sm text-slate-600">{selectedTraffic.description}</p>
+                      )}
+                      <div className="flex items-center gap-4 text-xs text-slate-400">
+                        <span>
+                          <MapPin className="mr-1 inline size-3" aria-hidden="true" />
+                          {selectedTraffic.latitude.toFixed(4)}, {selectedTraffic.longitude.toFixed(4)}
+                        </span>
+                        <span>
+                          Cập nhật: {new Date(selectedTraffic.updated_at).toLocaleString("vi-VN")}
+                        </span>
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <Car className="size-10 text-slate-300" aria-hidden="true" />
+                <p className="mt-2 text-sm text-slate-500">
+                  Chọn một tuyến đường để xem thông tin giao thông
+                </p>
+              </div>
+            )}
+          </Card>
+
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Danh sách tuyến đường
+            </h2>
+            <div className="space-y-3">
+              {mockTraffic.map((traffic) => {
+                const config = congestionConfig[traffic.congestion_level];
+                const CongestionIcon = config.icon;
+                return (
+                  <div
+                    key={traffic.id}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border p-3 transition-colors",
+                      selectedRoad === traffic.id
+                        ? "border-primary bg-primary/5"
+                        : "border-slate-200 hover:border-slate-300"
+                    )}
+                  >
+                    <div className={cn("rounded-full p-1.5", config.bgColor)}>
+                      <CongestionIcon className={cn("size-4", config.color)} aria-hidden="true" />
+                    </div>
+                    <div className="flex-1">
+                      <p className="text-sm font-medium text-slate-900">{traffic.road_name}</p>
+                      <p className={cn("text-xs font-medium", config.color)}>{config.label}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/fe/app/admin/weather/page.tsx
+++ b/fe/app/admin/weather/page.tsx
@@ -1,32 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { CloudSun, CloudRain, Cloud, CloudLightning, CloudFog, RefreshCw, MapPinned } from "lucide-react";
 import { Button } from "@/components/common/Button";
 import { Input } from "@/components/common/Input";
-import { PagePlaceholder } from "@/components/common/PagePlaceholder";
 import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { mockWeather, type WeatherData } from "@/lib/admin-data";
+import { cn } from "@/lib/utils";
+
+const conditionConfig: Record<WeatherData["condition"], { label: string; icon: typeof CloudSun; color: string }> = {
+  sunny: { label: "Nắng", icon: CloudSun, color: "text-amber-500" },
+  cloudy: { label: "Nhiều mây", icon: Cloud, color: "text-slate-500" },
+  rainy: { label: "Mưa", icon: CloudRain, color: "text-blue-500" },
+  stormy: { label: "Bão", icon: CloudLightning, color: "text-purple-500" },
+  foggy: { label: "Sương mù", icon: CloudFog, color: "text-gray-400" },
+};
 
 export default function AdminWeatherPage() {
+  const [selectedDestination, setSelectedDestination] = useState("");
+  const [formData, setFormData] = useState({
+    temperature: "",
+    humidity: "",
+    wind_speed: "",
+    condition: "",
+  });
+  const [loading, setLoading] = useState(false);
+
+  const selectedWeather = mockWeather.find(
+    (w) => w.destination_id === selectedDestination
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setLoading(false);
+    alert("Cập nhật thời tiết thành công!");
+  };
+
   return (
-    <PagePlaceholder
-      title="Cập nhật dữ liệu thời tiết"
-      description="Trang nhập hoặc đồng bộ dữ liệu thời tiết theo điểm/khu vực du lịch."
-      placeholder="Trang này là trang cập nhật dữ liệu thời tiết."
-      suggestions={[
-        "Kết nối bảng WeatherInfo.",
-        "Đồng bộ dữ liệu từ API thời tiết.",
-        "Thêm lịch sử quan sát theo thời gian.",
-      ]}
-    >
-      <div className="grid max-w-2xl gap-3 md:grid-cols-3">
-        <Select
-          defaultValue=""
-          options={[
-            { label: "Chọn điểm du lịch", value: "" },
-            { label: "Đại Nội Huế", value: "hue-citadel" },
-          ]}
-        />
-        <Input placeholder="Nhiệt độ" />
-        <Input placeholder="Độ ẩm" />
-        <Button className="md:col-span-3">Cập nhật thời tiết</Button>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+          Cập nhật dữ liệu thời tiết
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Nhập hoặc đồng bộ dữ liệu thời tiết theo điểm du lịch.
+        </p>
       </div>
-    </PagePlaceholder>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Thông tin thời tiết
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="destination" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Điểm du lịch
+                </label>
+                <Select
+                  id="destination"
+                  value={selectedDestination}
+                  onChange={(e) => setSelectedDestination(e.target.value)}
+                  options={[
+                    { label: "Chọn điểm du lịch", value: "" },
+                    ...mockWeather.map((w) => ({
+                      label: w.destination_name,
+                      value: w.destination_id,
+                    })),
+                  ]}
+                />
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label htmlFor="temperature" className="mb-1.5 block text-sm font-medium text-slate-700">
+                    Nhiệt độ (°C)
+                  </label>
+                  <Input
+                    id="temperature"
+                    type="number"
+                    placeholder="28"
+                    value={formData.temperature}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, temperature: e.target.value }))
+                    }
+                  />
+                </div>
+                <div>
+                  <label htmlFor="humidity" className="mb-1.5 block text-sm font-medium text-slate-700">
+                    Độ ẩm (%)
+                  </label>
+                  <Input
+                    id="humidity"
+                    type="number"
+                    placeholder="75"
+                    value={formData.humidity}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, humidity: e.target.value }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label htmlFor="wind_speed" className="mb-1.5 block text-sm font-medium text-slate-700">
+                    Tốc độ gió (km/h)
+                  </label>
+                  <Input
+                    id="wind_speed"
+                    type="number"
+                    placeholder="12"
+                    value={formData.wind_speed}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, wind_speed: e.target.value }))
+                    }
+                  />
+                </div>
+                <div>
+                  <label htmlFor="condition" className="mb-1.5 block text-sm font-medium text-slate-700">
+                    Trạng thái thời tiết
+                  </label>
+                  <Select
+                    id="condition"
+                    value={formData.condition}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, condition: e.target.value }))
+                    }
+                    options={[
+                      { label: "Chọn trạng thái", value: "" },
+                      { label: "Nắng", value: "sunny" },
+                      { label: "Nhiều mây", value: "cloudy" },
+                      { label: "Mưa", value: "rainy" },
+                      { label: "Bão", value: "stormy" },
+                      { label: "Sương mù", value: "foggy" },
+                    ]}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-6 flex gap-3">
+              <Button type="submit" disabled={loading || !selectedDestination}>
+                {loading ? (
+                  "Đang cập nhật..."
+                ) : (
+                  <>
+                    <RefreshCw className="mr-2 size-4" aria-hidden="true" />
+                    Cập nhật thời tiết
+                  </>
+                )}
+              </Button>
+            </div>
+          </Card>
+        </form>
+
+        <div className="space-y-4">
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Dữ liệu hiện tại
+            </h2>
+            {selectedWeather ? (
+              <div className="flex items-center gap-4">
+                {(() => {
+                  const config = conditionConfig[selectedWeather.condition];
+                  const WeatherIcon = config.icon;
+                  return (
+                    <>
+                      <div className="rounded-full bg-slate-100 p-4">
+                        <WeatherIcon className={cn("size-8", config.color)} aria-hidden="true" />
+                      </div>
+                      <div className="flex-1 space-y-2">
+                        <p className="text-lg font-semibold text-slate-900">
+                          {selectedWeather.destination_name}
+                        </p>
+                        <div className="flex flex-wrap gap-4 text-sm text-slate-600">
+                          <span>{selectedWeather.temperature}°C</span>
+                          <span>Độ ẩm: {selectedWeather.humidity}%</span>
+                          <span>Gió: {selectedWeather.wind_speed} km/h</span>
+                        </div>
+                        <p className="text-xs text-slate-400">
+                          Cập nhật: {new Date(selectedWeather.updated_at).toLocaleString("vi-VN")}
+                        </p>
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-8 text-center">
+                <MapPinned className="size-10 text-slate-300" aria-hidden="true" />
+                <p className="mt-2 text-sm text-slate-500">
+                  Chọn một điểm du lịch để xem thông tin thời tiết
+                </p>
+              </div>
+            )}
+          </Card>
+
+          <Card className="p-6">
+            <h2 className="mb-4 text-base font-semibold text-slate-950">
+              Danh sách điểm du lịch
+            </h2>
+            <div className="space-y-3">
+              {mockWeather.map((weather) => {
+                const config = conditionConfig[weather.condition];
+                const WeatherIcon = config.icon;
+                return (
+                  <div
+                    key={weather.id}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border p-3 transition-colors",
+                      selectedDestination === weather.destination_id
+                        ? "border-primary bg-primary/5"
+                        : "border-slate-200 hover:border-slate-300"
+                    )}
+                  >
+                    <WeatherIcon className={cn("size-5", config.color)} aria-hidden="true" />
+                    <div className="flex-1">
+                      <p className="text-sm font-medium text-slate-900">
+                        {weather.destination_name}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        {weather.temperature}°C, {config.label}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/fe/components/admin/DataTable.tsx
+++ b/fe/components/admin/DataTable.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "./LoadingState";
+import type { LucideIcon } from "lucide-react";
+import { MoreHorizontal, Edit, Trash2, Eye, EyeOff, Check, X, ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+export type Column<T> = {
+  key: string;
+  header: string;
+  width?: string;
+  sortable?: boolean;
+  render?: (row: T, index: number) => React.ReactNode;
+};
+
+export type Action<T> = {
+  label: string;
+  icon?: LucideIcon;
+  variant?: "default" | "outline" | "destructive" | "ghost";
+  onClick?: (row: T) => void;
+  href?: (row: T) => string;
+};
+
+type DataTableProps<T> = {
+  data: T[];
+  columns: Column<T>[];
+  actions?: Action<T>[];
+  keyExtractor: (row: T) => string;
+  emptyMessage?: string;
+  loading?: boolean;
+  className?: string;
+  pagination?: {
+    page: number;
+    pageSize: number;
+    total: number;
+    onPageChange: (page: number) => void;
+  };
+  selectable?: boolean;
+  selectedIds?: string[];
+  onSelectionChange?: (ids: string[]) => void;
+};
+
+export function DataTable<T>({
+  data,
+  columns,
+  actions = [],
+  keyExtractor,
+  emptyMessage = "Không có dữ liệu",
+  loading = false,
+  className,
+  pagination,
+  selectable = false,
+  selectedIds = [],
+  onSelectionChange,
+}: DataTableProps<T>) {
+  const [openActions, setOpenActions] = useState<string | null>(null);
+
+  const totalPages = pagination ? Math.ceil(pagination.total / pagination.pageSize) : 0;
+
+  const handleSelectAll = () => {
+    if (!onSelectionChange) return;
+    if (selectedIds.length === data.length) {
+      onSelectionChange([]);
+    } else {
+      onSelectionChange(data.map(keyExtractor));
+    }
+  };
+
+  const handleSelectRow = (id: string) => {
+    if (!onSelectionChange) return;
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((i) => i !== id));
+    } else {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={cn("rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden", className)}>
+        <div className="animate-pulse p-6 space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex gap-4">
+              {columns.map((col, j) => (
+                <div
+                  key={j}
+                  className="h-4 animate-pulse rounded bg-slate-200"
+                  style={{ width: col.width || "100px" }}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className={cn("rounded-xl border border-dashed border-slate-300 bg-slate-50/50 p-12 text-center", className)}>
+        <p className="text-sm text-slate-500">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden", className)}>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
+            <tr>
+              {selectable && (
+                <th className="w-12 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.length === data.length && data.length > 0}
+                    onChange={handleSelectAll}
+                    className="size-4 rounded border-slate-300 text-primary focus:ring-primary"
+                  />
+                </th>
+              )}
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  className={cn("px-4 py-3 font-semibold", col.sortable && "cursor-pointer hover:text-slate-900")}
+                  style={{ width: col.width }}
+                >
+                  {col.header}
+                </th>
+              ))}
+              {actions.length > 0 && <th className="w-16 px-4 py-3 text-right">Thao tác</th>}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {data.map((row, index) => {
+              const id = keyExtractor(row);
+              const isSelected = selectedIds.includes(id);
+
+              return (
+                <tr
+                  key={id}
+                  className={cn(
+                    "transition-colors hover:bg-slate-50/50",
+                    isSelected && "bg-primary/5"
+                  )}
+                >
+                  {selectable && (
+                    <td className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => handleSelectRow(id)}
+                        className="size-4 rounded border-slate-300 text-primary focus:ring-primary"
+                      />
+                    </td>
+                  )}
+                  {columns.map((col) => (
+                    <td key={col.key} className="px-4 py-3">
+                      {col.render ? col.render(row, index) : (row as Record<string, unknown>)[col.key] as React.ReactNode}
+                    </td>
+                  ))}
+                  {actions.length > 0 && (
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        {actions.length === 1 ? (
+                          (() => {
+                            const action = actions[0];
+                            const ActionIcon = action.icon;
+                            return action.href ? (
+                              <Button variant="ghost" size="sm" asChild>
+                                <Link href={action.href(row)}>
+                                  {ActionIcon && <ActionIcon className="size-4" aria-hidden="true" />}
+                                </Link>
+                              </Button>
+                            ) : (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => action.onClick?.(row)}
+                              >
+                                {ActionIcon && <ActionIcon className="size-4" aria-hidden="true" />}
+                              </Button>
+                            );
+                          })()
+                        ) : (
+                          <div className="relative">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => setOpenActions(openActions === id ? null : id)}
+                              aria-label="Mở menu thao tác"
+                            >
+                              <MoreHorizontal className="size-4" />
+                            </Button>
+                            {openActions === id && (
+                              <div className="absolute right-0 z-10 mt-1 w-40 rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+                                {actions.map((action, actionIndex) => {
+                                  const Icon = action.icon;
+                                  return (
+                                    <button
+                                      key={actionIndex}
+                                      onClick={() => {
+                                        action.onClick?.(row);
+                                        setOpenActions(null);
+                                      }}
+                                      className={cn(
+                                        "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
+                                        action.variant === "destructive"
+                                          ? "text-red-600 hover:bg-red-50"
+                                          : "text-slate-700 hover:bg-slate-50"
+                                      )}
+                                    >
+                                      {Icon && <Icon className="size-4" aria-hidden="true" />}
+                                      {action.label}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {pagination && totalPages > 1 && (
+        <div className="flex items-center justify-between border-t border-slate-200 px-4 py-3">
+          <p className="text-sm text-slate-500">
+            Hiển thị {(pagination.page - 1) * pagination.pageSize + 1} -{" "}
+            {Math.min(pagination.page * pagination.pageSize, pagination.total)} của {pagination.total}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => pagination.onPageChange(pagination.page - 1)}
+              disabled={pagination.page <= 1}
+            >
+              <ChevronLeft className="size-4" aria-hidden="true" />
+              Trước
+            </Button>
+            <span className="text-sm text-slate-600">
+              Trang {pagination.page} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => pagination.onPageChange(pagination.page + 1)}
+              disabled={pagination.page >= totalPages}
+            >
+              Sau
+              <ChevronRight className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fe/components/admin/DestinationForm.tsx
+++ b/fe/components/admin/DestinationForm.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, Save } from "lucide-react";
+import { Button } from "@/components/common/Button";
+import { Input } from "@/components/common/Input";
+import { Select } from "@/components/common/Select";
+import { Card } from "@/components/common/Card";
+import { REGION_PROVINCES } from "@/lib/constants";
+import { mockCategories } from "@/lib/admin-data";
+
+type DestinationFormData = {
+  name: string;
+  province: string;
+  category: string;
+  address: string;
+  latitude: string;
+  longitude: string;
+  ticket_price: string;
+  open_time: string;
+  close_time: string;
+  description: string;
+};
+
+type DestinationFormProps = {
+  initialData?: Partial<DestinationFormData>;
+  isEditing?: boolean;
+};
+
+export function DestinationForm({ initialData, isEditing = false }: DestinationFormProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState<DestinationFormData>({
+    name: initialData?.name || "",
+    province: initialData?.province || "",
+    category: initialData?.category || "",
+    address: initialData?.address || "",
+    latitude: initialData?.latitude || "",
+    longitude: initialData?.longitude || "",
+    ticket_price: initialData?.ticket_price || "",
+    open_time: initialData?.open_time || "07:00",
+    close_time: initialData?.close_time || "18:00",
+    description: initialData?.description || "",
+  });
+
+  const [errors, setErrors] = useState<Partial<Record<keyof DestinationFormData, string>>>({});
+
+  const handleChange = (field: keyof DestinationFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const validate = (): boolean => {
+    const newErrors: Partial<Record<keyof DestinationFormData, string>> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Tên điểm du lịch là bắt buộc";
+    }
+    if (!formData.province) {
+      newErrors.province = "Vui lòng chọn tỉnh/thành";
+    }
+    if (!formData.category) {
+      newErrors.category = "Vui lòng chọn loại hình";
+    }
+    if (!formData.address.trim()) {
+      newErrors.address = "Địa chỉ là bắt buộc";
+    }
+    if (!formData.ticket_price || isNaN(Number(formData.ticket_price))) {
+      newErrors.ticket_price = "Giá vé phải là số";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    setLoading(true);
+
+    // Simulate API call
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    setLoading(false);
+    router.push("/admin/destinations");
+  };
+
+  const categoryOptions = mockCategories.map((c) => ({
+    label: c.name,
+    value: c.name,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/admin/destinations">
+            <ArrowLeft className="mr-2 size-4" aria-hidden="true" />
+            Quay lại
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-950">
+            {isEditing ? "Sửa điểm du lịch" : "Thêm điểm du lịch"}
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            {isEditing
+              ? "Cập nhật thông tin điểm du lịch trong hệ thống."
+              : "Tạo mới một điểm du lịch trong hệ thống."}
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card className="p-6">
+          <h2 className="mb-4 text-base font-semibold text-slate-950">Thông tin cơ bản</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label htmlFor="name" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Tên điểm du lịch <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="name"
+                placeholder="Nhập tên điểm du lịch"
+                value={formData.name}
+                onChange={(e) => handleChange("name", e.target.value)}
+                className={errors.name ? "border-red-500 focus:border-red-500 focus:ring-red-100" : ""}
+              />
+              {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="province" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Tỉnh/Thành <span className="text-red-500">*</span>
+              </label>
+              <Select
+                id="province"
+                value={formData.province}
+                onChange={(e) => handleChange("province", e.target.value)}
+                options={[{ label: "Chọn tỉnh/thành", value: "" }, ...REGION_PROVINCES.map((p) => ({ label: p, value: p }))]}
+                className={errors.province ? "border-red-500 focus:border-red-500" : ""}
+              />
+              {errors.province && <p className="mt-1 text-xs text-red-500">{errors.province}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="category" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Loại hình du lịch <span className="text-red-500">*</span>
+              </label>
+              <Select
+                id="category"
+                value={formData.category}
+                onChange={(e) => handleChange("category", e.target.value)}
+                options={[{ label: "Chọn loại hình", value: "" }, ...categoryOptions]}
+                className={errors.category ? "border-red-500 focus:border-red-500" : ""}
+              />
+              {errors.category && <p className="mt-1 text-xs text-red-500">{errors.category}</p>}
+            </div>
+
+            <div className="sm:col-span-2">
+              <label htmlFor="address" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Địa chỉ <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="address"
+                placeholder="Nhập địa chỉ đầy đủ"
+                value={formData.address}
+                onChange={(e) => handleChange("address", e.target.value)}
+                className={errors.address ? "border-red-500 focus:border-red-500 focus:ring-red-100" : ""}
+              />
+              {errors.address && <p className="mt-1 text-xs text-red-500">{errors.address}</p>}
+            </div>
+
+            <div className="sm:col-span-2">
+              <label htmlFor="description" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Mô tả
+              </label>
+              <textarea
+                id="description"
+                placeholder="Nhập mô tả ngắn về điểm du lịch"
+                value={formData.description}
+                onChange={(e) => handleChange("description", e.target.value)}
+                rows={3}
+                className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-emerald-500 focus:ring-2 focus:ring-emerald-100"
+              />
+            </div>
+          </div>
+        </Card>
+
+        <Card className="p-6">
+          <h2 className="mb-4 text-base font-semibold text-slate-950">Thông tin bổ sung</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label htmlFor="ticket_price" className="mb-1.5 block text-sm font-medium text-slate-700">
+                Giá vé (VNĐ) <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="ticket_price"
+                type="number"
+                placeholder="0 = Miễn phí"
+                value={formData.ticket_price}
+                onChange={(e) => handleChange("ticket_price", e.target.value)}
+                className={errors.ticket_price ? "border-red-500 focus:border-red-500 focus:ring-red-100" : ""}
+              />
+              {errors.ticket_price && <p className="mt-1 text-xs text-red-500">{errors.ticket_price}</p>}
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label htmlFor="open_time" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Giờ mở cửa
+                </label>
+                <Input
+                  id="open_time"
+                  type="time"
+                  value={formData.open_time}
+                  onChange={(e) => handleChange("open_time", e.target.value)}
+                />
+              </div>
+              <div>
+                <label htmlFor="close_time" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Giờ đóng cửa
+                </label>
+                <Input
+                  id="close_time"
+                  type="time"
+                  value={formData.close_time}
+                  onChange={(e) => handleChange("close_time", e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label htmlFor="latitude" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Vĩ độ (Latitude)
+                </label>
+                <Input
+                  id="latitude"
+                  type="number"
+                  step="any"
+                  placeholder="16.0544"
+                  value={formData.latitude}
+                  onChange={(e) => handleChange("latitude", e.target.value)}
+                />
+              </div>
+              <div>
+                <label htmlFor="longitude" className="mb-1.5 block text-sm font-medium text-slate-700">
+                  Kinh độ (Longitude)
+                </label>
+                <Input
+                  id="longitude"
+                  type="number"
+                  step="any"
+                  placeholder="108.2139"
+                  value={formData.longitude}
+                  onChange={(e) => handleChange("longitude", e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" asChild>
+            <Link href="/admin/destinations">Hủy</Link>
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? (
+              "Đang lưu..."
+            ) : (
+              <>
+                <Save className="mr-2 size-4" aria-hidden="true" />
+                {isEditing ? "Cập nhật" : "Lưu điểm du lịch"}
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/fe/components/admin/EmptyState.tsx
+++ b/fe/components/admin/EmptyState.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/common/Button";
+import type { LucideIcon } from "lucide-react";
+import { Plus, PlusCircle, FileText, Search } from "lucide-react";
+
+type EmptyStateProps = {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  action?: {
+    label: string;
+    onClick?: () => void;
+    href?: string;
+  };
+  className?: string;
+};
+
+export function EmptyState({ title, description, icon: Icon, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50/50 p-8 text-center",
+        className
+      )}
+    >
+      {Icon && (
+        <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-slate-100">
+          <Icon className="size-6 text-slate-400" aria-hidden="true" />
+        </div>
+      )}
+      <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+      {description && <p className="mt-1 max-w-sm text-sm text-slate-500">{description}</p>}
+      {action && (
+        <div className="mt-4">
+          {action.href ? (
+            <Button asChild>
+              <a href={action.href}>
+                <Plus className="mr-2 size-4" aria-hidden="true" />
+                {action.label}
+              </a>
+            </Button>
+          ) : (
+            <Button onClick={action.onClick}>
+              <Plus className="mr-2 size-4" aria-hidden="true" />
+              {action.label}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type NoSearchResultsProps = {
+  keyword?: string;
+  onClear?: () => void;
+  className?: string;
+};
+
+export function NoSearchResults({ keyword, onClear, className }: NoSearchResultsProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white p-8 text-center",
+        className
+      )}
+    >
+      <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-slate-100">
+        <Search className="size-6 text-slate-400" aria-hidden="true" />
+      </div>
+      <h3 className="text-base font-semibold text-slate-900">Không tìm thấy kết quả</h3>
+      <p className="mt-1 text-sm text-slate-500">
+        {keyword ? `Không có kết quả cho từ khóa "${keyword}"` : "Không có dữ liệu phù hợp"}
+      </p>
+      {onClear && (
+        <Button variant="outline" onClick={onClear} className="mt-4">
+          Xóa tìm kiếm
+        </Button>
+      )}
+    </div>
+  );
+}
+
+type NoDataYetProps = {
+  title?: string;
+  description?: string;
+  className?: string;
+};
+
+export function NoDataYet({ title = "Chưa có dữ liệu", description, className }: NoDataYetProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white p-8 text-center",
+        className
+      )}
+    >
+      <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-slate-100">
+        <FileText className="size-6 text-slate-400" aria-hidden="true" />
+      </div>
+      <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+      {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+    </div>
+  );
+}

--- a/fe/components/admin/LoadingState.tsx
+++ b/fe/components/admin/LoadingState.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+type LoadingSpinnerProps = {
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const sizeClasses = {
+  sm: "size-4 border-2",
+  md: "size-6 border-2",
+  lg: "size-8 border-3",
+};
+
+export function LoadingSpinner({ size = "md", className }: LoadingSpinnerProps) {
+  return (
+    <div
+      className={cn(
+        "animate-spin rounded-full border-slate-200 border-t-primary",
+        sizeClasses[size],
+        className
+      )}
+      role="status"
+      aria-label="Đang tải"
+    />
+  );
+}
+
+type LoadingOverlayProps = {
+  message?: string;
+  className?: string;
+};
+
+export function LoadingOverlay({ message = "Đang tải...", className }: LoadingOverlayProps) {
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 z-50 flex flex-col items-center justify-center gap-3 rounded-xl bg-white/80 backdrop-blur-sm",
+        className
+      )}
+    >
+      <LoadingSpinner size="lg" />
+      <p className="text-sm font-medium text-slate-600">{message}</p>
+    </div>
+  );
+}
+
+type TableSkeletonProps = {
+  rows?: number;
+  columns?: number;
+  className?: string;
+};
+
+export function TableSkeleton({ rows = 5, columns = 4, className }: TableSkeletonProps) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex gap-4">
+        {Array.from({ length: columns }).map((_, i) => (
+          <div
+            key={i}
+            className="h-4 w-24 animate-pulse rounded bg-slate-200"
+          />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="flex gap-4">
+          {Array.from({ length: columns }).map((_, colIndex) => (
+            <div
+              key={colIndex}
+              className="h-8 w-full animate-pulse rounded bg-slate-100"
+              style={{ maxWidth: colIndex === 0 ? "200px" : `${100 - colIndex * 15}%` }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type CardSkeletonProps = {
+  className?: string;
+};
+
+export function CardSkeleton({ className }: CardSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+        className
+      )}
+    >
+      <div className="space-y-3">
+        <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+        <div className="h-8 w-16 animate-pulse rounded bg-slate-100" />
+      </div>
+    </div>
+  );
+}
+
+type StatsSkeletonProps = {
+  count?: number;
+  className?: string;
+};
+
+export function StatsSkeleton({ count = 4, className }: StatsSkeletonProps) {
+  return (
+    <div className={cn("grid gap-4 sm:grid-cols-2 lg:grid-cols-4", className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/fe/components/admin/StatusBadge.tsx
+++ b/fe/components/admin/StatusBadge.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+
+type StatusType = "success" | "warning" | "error" | "info" | "pending" | "default";
+
+type StatusBadgeProps = {
+  status: StatusType;
+  label: string;
+  icon?: LucideIcon;
+  className?: string;
+};
+
+const statusStyles: Record<StatusType, string> = {
+  success: "bg-emerald-50 text-emerald-800 border-emerald-200",
+  warning: "bg-amber-50 text-amber-800 border-amber-200",
+  error: "bg-red-50 text-red-800 border-red-200",
+  info: "bg-blue-50 text-blue-800 border-blue-200",
+  pending: "bg-slate-100 text-slate-600 border-slate-200",
+  default: "bg-slate-100 text-slate-700 border-slate-200",
+};
+
+const statusDotStyles: Record<StatusType, string> = {
+  success: "bg-emerald-500",
+  warning: "bg-amber-500",
+  error: "bg-red-500",
+  info: "bg-blue-500",
+  pending: "bg-slate-400",
+  default: "bg-slate-400",
+};
+
+export function StatusBadge({ status, label, icon: Icon, className }: StatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium",
+        statusStyles[status],
+        className
+      )}
+    >
+      <span className={cn("size-1.5 rounded-full", statusDotStyles[status])} />
+      {Icon && <Icon className="size-3" aria-hidden="true" />}
+      {label}
+    </span>
+  );
+}
+
+export function RatingBadge({ score, max = 5 }: { score: number; max?: number }) {
+  const percentage = (score / max) * 100;
+  let colorClass = "bg-slate-100 text-slate-600 border-slate-200";
+
+  if (percentage >= 80) {
+    colorClass = "bg-emerald-50 text-emerald-800 border-emerald-200";
+  } else if (percentage >= 60) {
+    colorClass = "bg-blue-50 text-blue-800 border-blue-200";
+  } else if (percentage >= 40) {
+    colorClass = "bg-amber-50 text-amber-800 border-amber-200";
+  } else {
+    colorClass = "bg-red-50 text-red-800 border-red-200";
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold",
+        colorClass
+      )}
+    >
+      {score.toFixed(1)}/{max}
+    </span>
+  );
+}
+
+export function CategoryBadge({ label, color }: { label: string; color?: string }) {
+  return (
+    <span
+      className="inline-flex items-center rounded-full bg-teal-50 px-2.5 py-1 text-xs font-medium text-teal-800 border border-teal-200"
+      style={color ? { backgroundColor: `${color}15`, color, borderColor: `${color}30` } : undefined}
+    >
+      {label}
+    </span>
+  );
+}

--- a/fe/lib/admin-data.ts
+++ b/fe/lib/admin-data.ts
@@ -1,0 +1,467 @@
+// Mock data types matching backend schemas
+
+export interface TouristDestination {
+  id: string;
+  name: string;
+  province: string;
+  category: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  ticket_price: number;
+  open_time: string;
+  close_time: string;
+  description: string;
+  status: "active" | "inactive" | "pending";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ServiceFacility {
+  id: string;
+  name: string;
+  type: "hotel" | "restaurant" | "parking" | "medical" | "toilet" | "atm" | "gas_station";
+  province: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  phone?: string;
+  status: "active" | "inactive";
+  created_at: string;
+}
+
+export interface DestinationCategory {
+  id: string;
+  name: string;
+  description: string;
+  icon?: string;
+  color?: string;
+  destinations_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Notification {
+  id: string;
+  title: string;
+  content: string;
+  type: "info" | "warning" | "alert" | "promotion";
+  destination_id?: string;
+  destination_name?: string;
+  status: "active" | "inactive" | "expired";
+  start_date: string;
+  end_date: string;
+  created_at: string;
+}
+
+export interface Review {
+  id: string;
+  user_id: string;
+  user_name: string;
+  destination_id: string;
+  destination_name: string;
+  rating: number;
+  content: string;
+  status: "pending" | "approved" | "hidden" | "rejected";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WeatherData {
+  id: string;
+  destination_id: string;
+  destination_name: string;
+  temperature: number;
+  humidity: number;
+  condition: "sunny" | "cloudy" | "rainy" | "stormy" | "foggy";
+  wind_speed: number;
+  updated_at: string;
+}
+
+export interface TrafficData {
+  id: string;
+  road_name: string;
+  congestion_level: "low" | "medium" | "high" | "blocked";
+  description?: string;
+  latitude: number;
+  longitude: number;
+  updated_at: string;
+}
+
+// Mock data
+export const mockDestinations: TouristDestination[] = [
+  {
+    id: "dest-001",
+    name: "Đại Nội Huế",
+    province: "Huế",
+    category: "Di sản",
+    address: "Đường Đại Đồng, Phường Thuỷ Vân, TP. Huế",
+    latitude: 16.4619,
+    longitude: 107.5779,
+    ticket_price: 150000,
+    open_time: "07:00",
+    close_time: "18:00",
+    description: "Cố đô Huế với kiến trúc hoàng gia nguy nga",
+    status: "active",
+    created_at: "2024-01-15T08:00:00Z",
+    updated_at: "2024-03-20T14:30:00Z",
+  },
+  {
+    id: "dest-002",
+    name: "Phố cổ Hội An",
+    province: "Đà Nẵng",
+    category: "Di sản",
+    address: "Đường Nguyễn Phúc, Phường Minh An, Hội An",
+    latitude: 15.8801,
+    longitude: 108.3385,
+    ticket_price: 80000,
+    open_time: "08:00",
+    close_time: "21:00",
+    description: "Phố cổ Hội An với kiến trúc truyền thống",
+    status: "active",
+    created_at: "2024-01-20T09:00:00Z",
+    updated_at: "2024-03-18T10:00:00Z",
+  },
+  {
+    id: "dest-003",
+    name: "Bãi biển Mỹ Khê",
+    province: "Đà Nẵng",
+    category: "Biển đảo",
+    address: "Đường Võ Nguyên Giáp, Phường Phước Mỹ, TP. Đà Nẵng",
+    latitude: 16.0544,
+    longitude: 108.2439,
+    ticket_price: 0,
+    open_time: "00:00",
+    close_time: "23:59",
+    description: "Một trong những bãi biển đẹp nhất thế giới",
+    status: "active",
+    created_at: "2024-02-01T10:00:00Z",
+    updated_at: "2024-03-15T08:00:00Z",
+  },
+  {
+    id: "dest-004",
+    name: "Thánh địa La Vang",
+    province: "Quảng Trị",
+    category: "Tâm linh",
+    address: "Thị trấn La Vang, Huyện Hải Lăng, Quảng Trị",
+    latitude: 16.5636,
+    longitude: 107.2111,
+    ticket_price: 0,
+    open_time: "05:00",
+    close_time: "21:00",
+    description: "Địa điểm hành hương tâm linh lớn nhất miền Trung",
+    status: "active",
+    created_at: "2024-02-10T11:00:00Z",
+    updated_at: "2024-03-10T09:00:00Z",
+  },
+  {
+    id: "dest-005",
+    name: "Đèo Hải Vân",
+    province: "Huế",
+    category: "Núi",
+    address: "Quốc lộ 1A, ranh giới Huế - Đà Nẵng",
+    latitude: 16.2014,
+    longitude: 108.1064,
+    ticket_price: 0,
+    open_time: "00:00",
+    close_time: "23:59",
+    description: "Một trong những đèo đẹp nổi tiếng Việt Nam",
+    status: "pending",
+    created_at: "2024-03-01T08:00:00Z",
+    updated_at: "2024-03-25T16:00:00Z",
+  },
+];
+
+export const mockServices: ServiceFacility[] = [
+  {
+    id: "svc-001",
+    name: "Khách sạn Pilgrimage Village",
+    type: "hotel",
+    province: "Huế",
+    address: "130 Nguyễn Khoa Chiêm, P.崔文, TP. Huế",
+    latitude: 16.4634,
+    longitude: 107.5749,
+    phone: "0234 388 6868",
+    status: "active",
+    created_at: "2024-01-10T08:00:00Z",
+  },
+  {
+    id: "svc-002",
+    name: "Nhà hàng Cơm Tấm Kiều Giang",
+    type: "restaurant",
+    province: "Đà Nẵng",
+    address: "89 Nguyễn Văn Linh, P. Nam Dương, Q. Hải Châu",
+    latitude: 16.0541,
+    longitude: 108.2222,
+    phone: "0236 388 8888",
+    status: "active",
+    created_at: "2024-01-12T09:00:00Z",
+  },
+  {
+    id: "svc-003",
+    name: "Bãi đỗ xe Phố cổ Hội An",
+    type: "parking",
+    province: "Đà Nẵng",
+    address: "Trần Hưng Đạo, P. Minh An, Hội An",
+    latitude: 15.8776,
+    longitude: 108.3294,
+    status: "active",
+    created_at: "2024-01-15T10:00:00Z",
+  },
+  {
+    id: "svc-004",
+    name: "Bệnh viện Đa khoa Trung ương Huế",
+    type: "medical",
+    province: "Huế",
+    address: "16 Lê Lợi, P. Vĩnh Ninh, TP. Huế",
+    latitude: 16.4689,
+    longitude: 107.5780,
+    phone: "0234 382 6225",
+    status: "active",
+    created_at: "2024-01-18T11:00:00Z",
+  },
+  {
+    id: "svc-005",
+    name: "ATM VietinBank - Đại Nội",
+    type: "atm",
+    province: "Huế",
+    address: "12 Đại Đồng, P. Thuỷ Vân, TP. Huế",
+    latitude: 16.4620,
+    longitude: 107.5780,
+    status: "inactive",
+    created_at: "2024-02-01T08:00:00Z",
+  },
+];
+
+export const mockCategories: DestinationCategory[] = [
+  {
+    id: "cat-001",
+    name: "Di sản",
+    description: "Các di sản văn hóa, lịch sử được UNESCO công nhận",
+    color: "#8b5cf6",
+    destinations_count: 12,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-03-01T00:00:00Z",
+  },
+  {
+    id: "cat-002",
+    name: "Biển đảo",
+    description: "Bãi biển, đảo và các hoạt động biển",
+    color: "#0ea5e9",
+    destinations_count: 25,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-03-01T00:00:00Z",
+  },
+  {
+    id: "cat-003",
+    name: "Núi",
+    description: "Đỉnh núi, rừng và các điểm leo núi",
+    color: "#22c55e",
+    destinations_count: 8,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-03-01T00:00:00Z",
+  },
+  {
+    id: "cat-004",
+    name: "Tâm linh",
+    description: "Đền, chùa, nhà thờ và các địa điểm tâm linh",
+    color: "#f59e0b",
+    destinations_count: 15,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-03-01T00:00:00Z",
+  },
+  {
+    id: "cat-005",
+    name: "Sinh thái",
+    description: "Vườn quốc gia, khu bảo tồn thiên nhiên",
+    color: "#10b981",
+    destinations_count: 6,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-03-01T00:00:00Z",
+  },
+];
+
+export const mockNotifications: Notification[] = [
+  {
+    id: "notif-001",
+    title: "Đóng cửa Đại Nội Huế để bảo tồn",
+    content: "Đại Nội Huế sẽ đóng cửa từ ngày 15/04 đến 20/04 để phục vụ công tác bảo tồn di sản.",
+    type: "warning",
+    destination_id: "dest-001",
+    destination_name: "Đại Nội Huế",
+    status: "active",
+    start_date: "2024-04-10T00:00:00Z",
+    end_date: "2024-04-25T23:59:00Z",
+    created_at: "2024-04-01T08:00:00Z",
+  },
+  {
+    id: "notif-002",
+    title: "Lễ hội phố cổ Hội An 2024",
+    content: "Lễ hội phố cổ Hội An diễn ra từ ngày 20/04 đến 25/04 với nhiều hoạt động văn hóa đặc sắc.",
+    type: "promotion",
+    destination_id: "dest-002",
+    destination_name: "Phố cổ Hội An",
+    status: "active",
+    start_date: "2024-04-15T00:00:00Z",
+    end_date: "2024-04-30T23:59:00Z",
+    created_at: "2024-04-05T10:00:00Z",
+  },
+  {
+    id: "notif-003",
+    title: "Cảnh báo mưa lớn khu vực Miền Trung",
+    content: "Dự báo mưa lớn trên diện rộng từ ngày 18/04. Du khách nên hạn chế di chuyển.",
+    type: "alert",
+    status: "active",
+    start_date: "2024-04-16T00:00:00Z",
+    end_date: "2024-04-20T23:59:00Z",
+    created_at: "2024-04-16T06:00:00Z",
+  },
+  {
+    id: "notif-004",
+    title: "Thông tin hữu ích về Mỹ Khê",
+    content: "Bãi biển Mỹ Khê được bình chọn trong top 10 bãi biển đẹp nhất châu Á.",
+    type: "info",
+    destination_id: "dest-003",
+    destination_name: "Bãi biển Mỹ Khê",
+    status: "inactive",
+    start_date: "2024-03-01T00:00:00Z",
+    end_date: "2024-03-31T23:59:00Z",
+    created_at: "2024-02-28T08:00:00Z",
+  },
+];
+
+export const mockReviews: Review[] = [
+  {
+    id: "rev-001",
+    user_id: "user-001",
+    user_name: "Nguyễn Văn Minh",
+    destination_id: "dest-001",
+    destination_name: "Đại Nội Huế",
+    rating: 5,
+    content: "Địa điểm tuyệt vời! Kiến trúc hoàng gia rất nguy nga và đẹp mắt. Nên đi vào buổi sáng sớm để tránh đông.",
+    status: "approved",
+    created_at: "2024-03-15T14:30:00Z",
+    updated_at: "2024-03-15T16:00:00Z",
+  },
+  {
+    id: "rev-002",
+    user_id: "user-002",
+    user_name: "Trần Thị Lan",
+    destination_id: "dest-002",
+    destination_name: "Phố cổ Hội An",
+    rating: 4,
+    content: "Phố cổ rất đẹp, đi lại thuận tiện. Tuy nhiên vào buổi tối khá đông, nên đi sớm hơn.",
+    status: "approved",
+    created_at: "2024-03-18T10:00:00Z",
+    updated_at: "2024-03-18T12:00:00Z",
+  },
+  {
+    id: "rev-003",
+    user_id: "user-003",
+    user_name: "Lê Hoàng Nam",
+    destination_id: "dest-003",
+    destination_name: "Bãi biển Mỹ Khê",
+    rating: 2,
+    content: "Bãi biển đẹp nhưng nước không trong lắm và có khá nhiều rác. Cần cải thiện vệ sinh.",
+    status: "pending",
+    created_at: "2024-03-20T09:00:00Z",
+    updated_at: "2024-03-20T09:00:00Z",
+  },
+  {
+    id: "rev-004",
+    user_id: "user-004",
+    user_name: "Phạm Thu Hà",
+    destination_id: "dest-001",
+    destination_name: "Đại Nội Huế",
+    rating: 1,
+    content: "DU KHÁCH TỐT NHẤT KHÔNG NÊN ĐẾN ĐÂY VÌ ĐÂY LÀ ĐỊA ĐIỂM CỦA BỌN PHẢN ĐỘNG",
+    status: "pending",
+    created_at: "2024-03-22T08:00:00Z",
+    updated_at: "2024-03-22T08:00:00Z",
+  },
+  {
+    id: "rev-005",
+    user_id: "user-005",
+    user_name: "Hoàng Đức Anh",
+    destination_id: "dest-004",
+    destination_name: "Thánh địa La Vang",
+    rating: 5,
+    content: "Nơi yên bình và tâm linh. Rất phù hợp để tìm lại sự bình yên trong tâm hồn.",
+    status: "approved",
+    created_at: "2024-03-19T11:00:00Z",
+    updated_at: "2024-03-19T14:00:00Z",
+  },
+];
+
+export const mockWeather: WeatherData[] = [
+  {
+    id: "weather-001",
+    destination_id: "dest-001",
+    destination_name: "Đại Nội Huế",
+    temperature: 28,
+    humidity: 75,
+    condition: "cloudy",
+    wind_speed: 12,
+    updated_at: "2024-03-25T10:00:00Z",
+  },
+  {
+    id: "weather-002",
+    destination_id: "dest-002",
+    destination_name: "Phố cổ Hội An",
+    temperature: 31,
+    humidity: 68,
+    condition: "sunny",
+    wind_speed: 8,
+    updated_at: "2024-03-25T10:00:00Z",
+  },
+  {
+    id: "weather-003",
+    destination_id: "dest-003",
+    destination_name: "Bãi biển Mỹ Khê",
+    temperature: 30,
+    humidity: 72,
+    condition: "sunny",
+    wind_speed: 15,
+    updated_at: "2024-03-25T10:00:00Z",
+  },
+];
+
+export const mockTraffic: TrafficData[] = [
+  {
+    id: "traffic-001",
+    road_name: "Quốc lộ 1A - Đoạn qua Đà Nẵng",
+    congestion_level: "high",
+    description: "Kẹt xe nghiêm trọng do construction",
+    latitude: 16.0544,
+    longitude: 108.2133,
+    updated_at: "2024-03-25T09:30:00Z",
+  },
+  {
+    id: "traffic-002",
+    road_name: "Đèo Hải Vân",
+    congestion_level: "low",
+    description: "Đường thông thoáng, tầm nhìn tốt",
+    latitude: 16.2014,
+    longitude: 108.1064,
+    updated_at: "2024-03-25T09:30:00Z",
+  },
+  {
+    id: "traffic-003",
+    road_name: "Cầu Tràng Tiền, Huế",
+    congestion_level: "medium",
+    description: "Ùn ứ nhẹ vào giờ cao điểm",
+    latitude: 16.4689,
+    longitude: 107.5906,
+    updated_at: "2024-03-25T09:30:00Z",
+  },
+];
+
+// Dashboard stats
+export const getDashboardStats = () => ({
+  destinations: mockDestinations.length,
+  services: mockServices.length,
+  reviews: mockReviews.length,
+  notifications: mockNotifications.filter((n) => n.status === "active").length,
+  pendingReviews: mockReviews.filter((r) => r.status === "pending").length,
+  activeDestinations: mockDestinations.filter((d) => d.status === "active").length,
+});

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -94,7 +94,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -618,7 +617,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1784,7 +1782,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3802,7 +3799,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3813,7 +3809,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3824,7 +3819,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3886,7 +3880,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -4425,7 +4418,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4919,7 +4911,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5901,7 +5892,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6087,7 +6077,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6401,7 +6390,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7116,7 +7104,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9267,7 +9254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9532,7 +9518,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9542,7 +9527,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10695,7 +10679,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10944,7 +10927,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11518,7 +11500,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Progress

Triển khai nhóm trang quản trị trong `fe/app/admin` theo phạm vi yêu cầu:

- **Dashboard**: Stats cards hiển thị số lượng điểm du lịch, dịch vụ, đánh giá, thông báo + activity feed
- **Điểm du lịch**: Bảng quản lý + form thêm/sửa với các field: name, province, category, address, ticket_price, open/close time, latitude/longitude
- **Dịch vụ hỗ trợ**: Bảng quản lý với filter theo service type
- **Loại hình du lịch**: CRUD UI với color-coded badges
- **Thông báo**: Bảng quản lý với filter theo type/status
- **Thời tiết/Giao thông**: Form cập nhật theo điểm/khu vực
- **Đánh giá**: Bảng đánh giá + trang kiểm duyệt với action duyệt/ẩn/xóa

**Components mới:**
- `DataTable`: Bảng tái sử dụng với search, filter, actions
- `StatusBadge`: Badge trạng thái
- `EmptyState`, `LoadingState`: UI states
- `DestinationForm`: Form điểm du lịch

**Mock data**: `fe/lib/admin-data.ts` chứa dữ liệu mẫu cho tất cả entities, dễ chuyển sang API.

## Result

- Toàn bộ route `/admin/**` render UI quản trị cụ thể, không còn placeholder
- Component table/form tái sử dụng cho admin
- Form thêm/sửa điểm du lịch có đầy đủ field theo schema TouristDestination
- UI có trạng thái empty/loading/error
- `npm --prefix fe run lint` pass
- `npm --prefix fe run build` pass

---

Closes #12